### PR TITLE
Normalize indexing

### DIFF
--- a/algorithms/elasticsearch_indexers/base.py
+++ b/algorithms/elasticsearch_indexers/base.py
@@ -1,0 +1,66 @@
+"""
+Base class for Elasticsearch indexers
+
+Subclasses implement the index setting definition and transformation of data,
+The base class handles index management and bulk indexing with ES
+"""
+import logging
+from utils.es import get_index_from_alias, zero_downtime_index
+from elasticsearch.helpers import streaming_bulk
+from config import config
+
+
+class ElasticsearchIndexerBase(object):
+    def __init__(self, s3_conn, es_client, app_config=None):
+        """
+        Args:
+            s3_conn - a boto s3 connection
+            es_client - an Elasticsearch indices client
+            config (dict) config to override YAML file config
+        """
+        self.s3_conn = s3_conn
+        self.es_client = es_client
+        self.config = app_config or config
+
+    def index_config(self):
+        """Combines setting and mapping config into a full index configuration
+        Returns: dict
+        """
+        return {
+            'settings': self.settings,
+            'mappings': self.mappings
+        }
+
+    def replace(self):
+        """Replace index with a new one
+        zero_downtime_index for safety and rollback
+        """
+        with zero_downtime_index(self.index_name, self.index_config()) as target_index:
+            self.index_all(target_index)
+
+    def append(self):
+        """Index documents onto an existing index"""
+        target_index = get_index_from_alias(self.alias_name)
+        self.index_all(target_index)
+
+    def index_all(self, index_name):
+        """Index all available documents, using streaming_bulk for speed
+        Args:
+
+        index_name (string): The index
+        """
+        oks = 0
+        notoks = 0
+        for ok, item in streaming_bulk(
+            self.es_client,
+            self._iter_documents(index_name)
+        ):
+            if ok:
+                oks += 1
+            else:
+                notoks += 1
+        logging.info(
+            "Import results: %d ok, %d not ok",
+            oks,
+            notoks
+        )

--- a/algorithms/elasticsearch_indexers/job_titles_master.py
+++ b/algorithms/elasticsearch_indexers/job_titles_master.py
@@ -1,0 +1,100 @@
+"""
+Index job title/occupation pairs in Elasticsearch.
+"""
+import uuid
+
+from algorithms.elasticsearch_indexers.base import ElasticsearchIndexerBase
+
+
+class JobTitlesMasterIndexer(ElasticsearchIndexerBase):
+    """
+    Args: job_title_generator (iterable). Each record is expected to be a dict
+        with keys
+        'Title' for the job title and
+        'Original Title' for the occupation
+    """
+    def __init__(self, job_title_generator, **kwargs):
+        super(JobTitlesMasterIndexer, self).__init__(**kwargs)
+        self.job_title_generator = job_title_generator
+        self.alias_name = self.config['normalizer']['titles_master_index_name']
+
+    settings = {
+        "number_of_shards": 1,
+        "analysis": {
+            "analyzer": {
+                "english": {
+                    "tokenizer":  "standard",
+                    "filter": [
+                        "english_possessive_stemmer",
+                        "lowercase",
+                        "english_stop",
+                        "english_stemmer"
+                    ]
+                }
+            },
+            "filter": {
+                "english_stop": {
+                    "type":       "stop",
+                    "stopwords":  "_english_"
+                },
+                "english_stemmer": {
+                    "type":       "stemmer",
+                    "language":   "english"
+                },
+                "english_possessive_stemmer": {
+                    "type":       "stemmer",
+                    "language":   "possessive_english"
+                }
+            }
+        }
+    }
+    mappings = {
+        "titles": {
+            "properties": {
+                "occupation": {"type": "string", "analyzer": "english"},
+                "jobtitle": {"type": "string", "analyzer": "english"}
+            }
+        }
+    }
+
+    data_keys = {
+        'jobtitle': 'Title',
+        'occupation': 'Original Title'
+    }
+
+    def generate_index_args(self, row, target_index):
+        """Generate a job title/occupation record in a
+        format that Elasticsearch can consume
+
+        Args:
+        row (dict) a data row representing one job/occupation pair
+        target_index (string) the index to send the record
+
+        Returns: dict
+        """
+        indexed_data = {
+            key: row[value]
+            for key, value in self.data_keys.items()
+        }
+        return {
+            "_op_type": 'index',
+            "_index": target_index,
+            "_type": "titles",
+            "_id": str(uuid.uuid4()),
+            "_score": 1,
+            "_source": indexed_data
+        }
+
+    def _iter_documents(self, target_index):
+        """Take all available job titles and transform them into a format
+        that Elasticsearch can index
+
+        Args:
+            target_index (string): the desired Elasticsearch index
+
+        Returns: generator which yields dicts
+        """
+        return (
+            self.generate_index_args(row, target_index)
+            for row in self.job_title_generator
+        )

--- a/algorithms/elasticsearch_indexers/normalize_topn.py
+++ b/algorithms/elasticsearch_indexers/normalize_topn.py
@@ -1,0 +1,149 @@
+"""
+Indexes job postings for job title normalization
+"""
+import uuid
+import json
+
+from algorithms.elasticsearch_indexers.base import ElasticsearchIndexerBase
+
+
+class NormalizeTopNIndexer(ElasticsearchIndexerBase):
+    settings = {
+        "number_of_shards": 1,
+        "index.codec": "best_compression",
+        "analysis": {
+            "analyzer": {
+                "english": {
+                    "tokenizer":  "standard",
+                    "filter": [
+                        "english_possessive_stemmer",
+                        "lowercase",
+                        "english_stop",
+                        "english_stemmer"
+                    ]
+                }
+            },
+            "filter": {
+                "english_stop": {
+                    "type":       "stop",
+                    "stopwords":  "_english_"
+                },
+                "english_stemmer": {
+                    "type":       "stemmer",
+                    "language":   "english"
+                },
+                "english_possessive_stemmer": {
+                    "type":       "stemmer",
+                    "language":   "possessive_english"
+                }
+            }
+        },
+    }
+    mappings = {
+        "titles": {
+            "_all": {"enabled": False},
+            "properties": {
+                "occupation": {"type": "string"},
+                "jobtitle": {"type": "string"},
+                "jobdesc": {"type": "string", "analyzer": "english"}
+            }
+        }
+    }
+
+    data_keys = {
+        'occupation': 'occupationalCategory',
+        'jobdesc': 'description',
+        'jobtitle': 'title'
+    }
+
+    def __init__(self, quarter, job_postings_generator, **kwargs):
+        """
+        Args:
+            quarter (string) the quarter from which to retrieve job postings
+            job_postings_generator (iterable) an iterable of job postings
+        """
+        super(NormalizeTopNIndexer, self).__init__(**kwargs)
+        self.quarter = quarter
+        self.job_postings_generator = job_postings_generator
+        self.job_titles_index = self.config['normalizer']['titles_master_index_name']
+        self.alias_name = self.config['normalizer']['es_index_name']
+
+    def retrieve_top_titles(self, jobdesc, occupation):
+        """Retrieves job titles from Elasticsearch that match the arguments
+
+        Queries the job title/occupation index for:
+        1. job titles or occupations that match the job description
+        2. Occupation matches
+        The top three results are returned
+
+        Args:
+            jobdesc (string) A job description
+            occupation (string) An occupation
+
+        Returns: A list of strings, each a matching job titles
+        """
+        body = {
+            "size": 3,
+            "_source": ["jobtitle"],
+            "query": {
+                "bool": {
+                    "should": [
+                        {"multi_match": {
+                            "fields": ["jobtitle", "occupation"],
+                            "query": jobdesc[:1000],
+                        }},
+                        {"match": {"occupation": occupation}}
+                    ]
+                }
+            }
+        }
+        response = self.es_client.search(index=self.job_titles_index, body=body)
+        results = response['hits']['hits']
+        return [row['_source']['jobtitle'][0] for row in results]
+
+    def generate_index_args(self, posting, target_index):
+        """Generate indexable job posting records
+
+        Queries the Elasticsearch job title index for the
+        closest job titles matching the description and occupation, and returns
+        the top three results
+
+        Args:
+        posting (dict) A job posting
+        target_index (string) The desired Elasticseach index
+
+        Yields: dicts representing indexable records
+        """
+        indexed_data = {
+            key: posting[value]
+            for key, value in self.data_keys.items()
+        }
+        indexed_data['quarters'] = [self.quarter]
+        for matched_title in self.retrieve_top_titles(
+            indexed_data['jobdesc'],
+            indexed_data['occupation']
+        ):
+            indexed_data['canonicaltitle'] = matched_title
+            yield {
+                "_op_type": 'index',
+                "_index": target_index,
+                "_type": "titles",
+                "_id": str(uuid.uuid4()),
+                "_score": 1,
+                "_source": indexed_data
+            }
+
+    def _iter_documents(self, target_index):
+        """Take all available job postings and generates documents
+        that Elasticsearch can index
+
+        Args:
+            target_index (string): the desired Elasticsearch index
+
+        Returns: generator which yields dicts
+        """
+        return (
+            data
+            for posting in self.job_postings_generator(self.s3_conn, self.quarter)
+            for data in self.generate_index_args(json.loads(posting), target_index)
+        )

--- a/config.py
+++ b/config.py
@@ -1,5 +1,11 @@
 """Load configuration from a yaml file"""
+import logging
+import os
 import yaml
 
-with open('config.yaml', 'r') as f:
-    config = yaml.load(f)
+if os.path.exists('config.yaml'):
+    with open('config.yaml', 'r') as f:
+        config = yaml.load(f)
+else:
+    logging.warning('No config file found, using empty config')
+    config = {}

--- a/dags/index_job_titles_master.py
+++ b/dags/index_job_titles_master.py
@@ -1,0 +1,48 @@
+"""Index job titles master table
+
+Indexes all job title and occupation pairs the API knows about
+"""
+
+import csv
+import io
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators import BaseOperator
+from airflow.hooks import S3Hook
+
+from config import config
+from utils.es import basic_client
+from utils.s3 import split_s3_path
+
+from algorithms.elasticsearch_indexers.job_titles_master import JobTitlesMasterIndexer
+
+default_args = {
+    'depends_on_past': False,
+    'start_date': datetime.today(),
+}
+
+dag = DAG(
+    'index_job_titles_master',
+    schedule_interval=None,
+    default_args=default_args
+)
+
+
+class IndexJobTitlesMasterOperator(BaseOperator):
+    def execute(self, context):
+        conn = S3Hook()
+        input_bucket, input_prefix = split_s3_path(config['output_tables']['s3_path'])
+        key = conn.get_key(
+            '{}/job_titles_master_table.tsv'.format(input_prefix),
+            bucket_name=input_bucket
+        )
+        text = key.get_contents_as_string().decode('utf-8')
+        reader = csv.DictReader(io.StringIO(text), delimiter='\t')
+        JobTitlesMasterIndexer(
+            s3_conn=conn.get_conn(),
+            es_client=basic_client(),
+            job_title_generator=reader
+        ).replace()
+
+IndexJobTitlesMasterOperator(task_id='job_titles_master', dag=dag)

--- a/dags/normalize_elasticsearch.py
+++ b/dags/normalize_elasticsearch.py
@@ -1,0 +1,41 @@
+"""Index job postings
+
+Take job postings from the common schema and index them along with
+likely normalized job titles
+"""
+
+from airflow import DAG
+from airflow.operators import BaseOperator
+from airflow.hooks import S3Hook
+
+from utils.es import basic_client
+from algorithms.elasticsearch_indexers.normalize_topn import NormalizeTopNIndexer
+from utils.airflow import datetime_to_quarter
+from datetime import datetime
+from datasets import job_postings
+
+# some DAG args, please tweak for sanity
+default_args = {
+    'depends_on_past': False,
+    'start_date': datetime.today(),
+}
+
+dag = DAG(
+    'normalize_elasticsearch',
+    schedule_interval=None,
+    default_args=default_args
+)
+
+
+class IndexQuarterOperator(BaseOperator):
+    def execute(self, context):
+        conn = S3Hook().get_conn()
+        quarter = datetime_to_quarter(context['execution_date'])
+        NormalizeTopNIndexer(
+            quarter=quarter,
+            job_postings_generator=job_postings,
+            s3_conn=conn,
+            es_client=basic_client()
+        ).append()
+
+common_schema_quarterly = IndexQuarterOperator(task_id='common_schema_quarterly', dag=dag)

--- a/datasets.py
+++ b/datasets.py
@@ -17,7 +17,7 @@ def job_postings(s3_conn, quarter, s3_path=None):
     Stream all job listings from s3 for a given quarter
     Args:
         s3_conn: a boto s3 connection
-        quarter: a string representing a quarter (Q12015)
+        quarter: a string representing a quarter (2015Q1)
         s3_path (optional): path to the job listings. Defaults to config file
 
     Yields:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,7 @@ airflow[s3]
 PyYAML
 tox
 codecov
+httpretty
 Sphinx
 pytest-cov
+Elasticsearch

--- a/tests/test_es_indexers.py
+++ b/tests/test_es_indexers.py
@@ -1,0 +1,98 @@
+import httpretty
+import json
+import re
+
+from utils.es import basic_client
+
+from algorithms.elasticsearch_indexers.job_titles_master import JobTitlesMasterIndexer
+from algorithms.elasticsearch_indexers.normalize_topn import NormalizeTopNIndexer
+
+
+def test_index_titles():
+    input_data = [
+        {'Title': 'Job 1', 'Original Title': 'Occupation 1'},
+        {'Title': 'Job 2', 'Original Title': 'Occupation 2'},
+        {'Title': 'Job 3', 'Original Title': 'Occupation 3'},
+    ]
+
+    indexer = JobTitlesMasterIndexer(
+        job_title_generator=input_data,
+        app_config={'normalizer': {'titles_master_index_name': 'stuff'}},
+        s3_conn=None,
+        es_client=basic_client()
+    )
+
+    index = 'stuff'
+
+    documents = [document for document in indexer._iter_documents(target_index=index)]
+
+    assert len(documents) == 3
+
+    for document in documents:
+        assert 'Occupation ' in document['_source']['occupation']
+        assert 'Job ' in document['_source']['jobtitle']
+        assert document['_index'] == index
+        assert document['_id']
+
+
+def mock_job_posting_generator(postings):
+    return lambda s3_conn, quarter: (json.dumps(post) for post in postings)
+
+
+@httpretty.activate
+def test_normalize_topn():
+    generator = mock_job_posting_generator((
+        {
+            'occupationalCategory': 'Line Cooks, Chefs',
+            'description': 'A food job description',
+            'title': 'Food Truck Sous Chef'
+        },
+        {
+            'occupationalCategory': 'Actors',
+            'description': 'An actor job description',
+            'title': 'Broadway Star'
+        },
+    ))
+    indexer = NormalizeTopNIndexer(
+        s3_conn=None,
+        es_client=basic_client(),
+        app_config={
+            'normalizer': {
+                'titles_master_index_name': 'stuff',
+                'es_index_name': 'otherstuff'
+            }
+        },
+        quarter='2014Q1',
+        job_postings_generator=generator
+    )
+
+    # TODO: abstract the ES mocking to a module
+    # This means that the titles endpoint will say that all input job titles
+    # match best with 'Janitor'
+    mock_result = {
+        'hits': {
+            'hits': [
+                {'_source': {'jobtitle': ['Janitor']}}
+            ]
+        }
+    }
+    httpretty.register_uri(
+        httpretty.GET,
+        re.compile('http://localhost:9200/stuff/_search'),
+        body=json.dumps(mock_result),
+        content_type='application/json'
+    )
+
+    index = 'stuff'
+
+    documents = [document for document in indexer._iter_documents(target_index=index)]
+
+    assert len(documents) == 2
+
+    for document in documents:
+        assert document['_source']['canonicaltitle'] == 'Janitor'
+        assert document['_source']['quarters'] == ['2014Q1']
+        assert document['_source']['occupation'] in ['Line Cooks, Chefs', 'Actors']
+        assert document['_source']['jobtitle'] in ['Food Truck Sous Chef', 'Broadway Star']
+        assert document['_index'] == index
+        assert document['_id']

--- a/utils/es.py
+++ b/utils/es.py
@@ -1,0 +1,83 @@
+from elasticsearch import Elasticsearch, TransportError
+from elasticsearch.client import IndicesClient
+import contextlib
+import logging
+import os
+import time
+import uuid
+
+HOSTNAME = os.getenv('ELASTICSEARCH_ENDPOINT', 'localhost:9200')
+
+
+def basic_client():
+    es_connected = False
+    while not es_connected:
+        try:
+            ES = Elasticsearch(
+                hosts=[HOSTNAME]
+            )
+            es_connected = True
+        except TransportError as e:
+            logging.info('Not yet connected: %s, sleeping for 1s', e)
+            time.sleep(1)
+    return ES
+
+
+def indices_client():
+    es_connected = False
+    while not es_connected:
+        try:
+            ES = Elasticsearch(
+                hosts=[HOSTNAME]
+            )
+            es_connected = True
+        except TransportError as e:
+            logging.info('Not yet connected: %s, sleeping for 1s', e)
+            time.sleep(1)
+    return IndicesClient(ES)
+
+
+def create_index(index_name, index_config, client):
+    client.create(index=index_name, body=index_config)
+
+
+def get_index_from_alias(alias_name, index_client=None):
+    index_client = index_client or indices_client()
+    return list(index_client.get_alias(name=alias_name).keys())[0]
+
+
+def atomic_swap(alias_name, new_index_name, index_client):
+    logging.info('Performing atomic index alias swap')
+    if index_client.exists_alias(name=alias_name):
+        old_index_name = get_index_from_alias(alias_name, index_client)
+        logging.info('Removing old as well as adding new')
+        actions = {'actions': [
+            {'remove': {'index': old_index_name, 'alias': alias_name}},
+            {'add': {'index': new_index_name, 'alias': alias_name}}
+        ]}
+        index_client.update_aliases(body=actions)
+        index_client.delete(index=old_index_name)
+    else:
+        logging.info('Old alias not found, only adding new')
+        actions = {'actions': [
+            {'add': {'index': new_index_name, 'alias': alias_name}}
+        ]}
+        index_client.update_aliases(body=actions)
+
+
+@contextlib.contextmanager
+def zero_downtime_index(index_name, index_config):
+    client = indices_client()
+    temporary_name = index_name + '_' + str(uuid.uuid4())
+    logging.info('creating index with config %s', index_config)
+    create_index(temporary_name, index_config, client)
+    try:
+        yield temporary_name
+        atomic_swap(index_name, temporary_name, client)
+    except Exception:
+        logging.error(
+            'deleting temporary index %s due to error:',
+            temporary_name,
+            exc_info=True
+        )
+        client.delete(index=temporary_name)


### PR DESCRIPTION
Porting the existing Elasticsearch normalizer to use the common schema. I took the opportunity to abstract some of the utilities I had already written in the old version, to remove some boilerplate when indexing things.

I kept these as separate DAGs because indexing the job title list only really happens once, or whenever we recompute the job titles master table. The normalization indexing step itself is based on job postings, and so it makes sense quarterly. This means it doesn't make sense to put them in the same DAG.

I think there is a DAG reorganization coming in general, as parts of the simple_machine_learning DAG belong with parts of this. But in adding all this code I didn't want to mix too much of that code in, to make this easier to read.