### PR TITLE
Test ESA Job Normalizer

### DIFF
--- a/algorithms/job_normalizers/esa_jobtitle_normalizer.py
+++ b/algorithms/job_normalizers/esa_jobtitle_normalizer.py
@@ -6,11 +6,8 @@ import itertools
 import nltk
 import re
 import numpy as np
-import requests
-import zipfile
-import io
-import os
 import logging
+from datasets import OnetSourceDownloader
 
 ONET_VERSIONS = [
     'db_21_0_text',
@@ -32,53 +29,12 @@ ONET_VERSIONS = [
     'db_10_0',
 ]
 
-URL_PREFIX = 'http://www.onetcenter.org/dl_files'
 
-def get_onet_db(version):
-    directory = 'tmp/'
-    if not os.path.isdir(directory):
-        os.mkdir(directory)
-    destination_filename = directory + version + '_occupation_data.txt'
-    if not os.path.isfile(destination_filename):
-        logging.info('Could not find %s, downloading', destination_filename)
-        url_suffix = '{}.zip'.format(version)
-        if version > 'db_20_0':
-            zip_file_url = '/'.join([URL_PREFIX, 'database', url_suffix])
-        else:
-            zip_file_url = '/'.join([URL_PREFIX, url_suffix])
-        logging.info(zip_file_url)
-        response = requests.get(zip_file_url)
-        z = zipfile.ZipFile(io.BytesIO(response.content))
-        source_filename = '{}/Occupation Data.txt'.format(version)
-        logging.info('Extracting occupation data')
-        with z.open(source_filename) as input_file:
-            with open(destination_filename, 'wb') as output_file:
-                output_file.write(input_file.read())
-    return destination_filename
-
-def retrieve_onet_titles():
-    onet_titles = pd.concat(
-        (pd.read_csv(get_onet_db(version), sep='\t') for version in ONET_VERSIONS),
-        ignore_index=True
-    )
-    # Assumes pandas 0.19, keeps newest duplicate Title
-    onet_titles.drop_duplicates('Title', inplace=True, keep='last')
-    onet_titles['Major'] = onet_titles.iloc[:, 0].apply(lambda x: x[:2])
-
-    LOWER = True
-    if LOWER:
-        # all RDD strings are unicode
-        onet_titles['Title'] = onet_titles['Title'].str.lower()
-        onet_titles['Description'] = onet_titles['Description'].str.lower()
-
-    # now we can do a title -> Major, Minor lookup
-    onet_titles.set_index('Title', inplace=True)
-    # access with onet_titles.loc[u'Sales Agents, Financial Services']
-    return onet_titles
 
 class ESANormalizer(object):
-    def __init__(self):
-        self.onet_titles = retrieve_onet_titles()
+    def __init__(self, onet_source=OnetSourceDownloader):
+        self.onet_downloader = onet_source()
+        self.onet_titles = self.retrieve_onet_titles()
         logging.info('Retrieved onet titles')
         # ... Following the ESA description:
         # https://en.wikipedia.org/wiki/Explicit_semantic_analysis
@@ -90,6 +46,30 @@ class ESANormalizer(object):
             wn.synset
         except LookupError:
             nltk.download('wordnet')
+
+    def retrieve_onet_titles(self):
+        onet_titles = pd.concat(
+            (pd.read_csv(self.onet_downloader.download(
+                version,
+                'Occupation Data.txt',
+                'occupation_data.txt'
+            ), sep='\t') for version in ONET_VERSIONS),
+            ignore_index=True
+        )
+        # Assumes pandas 0.19, keeps newest duplicate Title
+        onet_titles.drop_duplicates('Title', inplace=True, keep='last')
+        onet_titles['Major'] = onet_titles.iloc[:, 0].apply(lambda x: x[:2])
+
+        LOWER = True
+        if LOWER:
+            # all RDD strings are unicode
+            onet_titles['Title'] = onet_titles['Title'].str.lower()
+            onet_titles['Description'] = onet_titles['Description'].str.lower()
+
+        # now we can do a title -> Major, Minor lookup
+        onet_titles.set_index('Title', inplace=True)
+        # access with onet_titles.loc[u'Sales Agents, Financial Services']
+        return onet_titles
 
     def hypernym_product(self, job_title):
         word_hypernyms = []
@@ -103,7 +83,6 @@ class ESANormalizer(object):
 
         for hypernym_title in itertools.product(*word_hypernyms):
             yield hypernym_title
-
 
     def concept_rank(self, words):
         """
@@ -137,6 +116,7 @@ class ESANormalizer(object):
         ret = []
         for title in self.hypernym_product(job_title):
             for concept in self.concept_rank(title):
+                #logging.warning(concept)
                 normalized_titles.append(concept)
         for item in sorted(normalized_titles,
                            key=lambda x: x['relevance_score'],

--- a/datasets.py
+++ b/datasets.py
@@ -5,6 +5,9 @@ import contextlib
 import logging
 import os
 import tempfile
+import requests
+import zipfile
+import io
 
 import boto
 
@@ -78,3 +81,27 @@ class OnetCache(object):
             )
             key.get_contents_to_filename(full_path)
             yield full_path
+
+
+class OnetSourceDownloader(object):
+    url_prefix = 'http://www.onetcenter.org/dl_files'
+    directory = 'tmp/'
+
+    def download(self, version, source_file, output_filename):
+        destination_filename = self.directory + version + '_' + output_filename
+        if not os.path.isfile(destination_filename):
+            logging.info('Could not find %s, downloading', destination_filename)
+            url_suffix = '{}.zip'.format(version)
+            if version > 'db_20_0':
+                zip_file_url = '/'.join([self.url_prefix, 'database', url_suffix])
+            else:
+                zip_file_url = '/'.join([self.url_prefix, url_suffix])
+            logging.info(zip_file_url)
+            response = requests.get(zip_file_url)
+            z = zipfile.ZipFile(io.BytesIO(response.content))
+            source_filename = '{}/{}'.format(version, source_file)
+            logging.info('Extracting occupation data')
+            with z.open(source_filename) as input_file:
+                with open(destination_filename, 'wb') as output_file:
+                    output_file.write(input_file.read())
+        return destination_filename

--- a/tests/test_esa_job_normalizer.py
+++ b/tests/test_esa_job_normalizer.py
@@ -1,0 +1,23 @@
+from algorithms.job_normalizers.esa_jobtitle_normalizer import ESANormalizer
+from mock import patch
+from tests import utils
+
+occupation_content = [
+    ['O*NET-SOC Code', 'Title', 'Description'],
+    ['11-1011.00', 'Chief Executives', 'Determine and formulate policies and provide overall direction of companies or private and public sector organizations within guidelines set up by a board of directors or similar governing body. Plan, direct, or coordinate operational activities at the highest level of management with the help of subordinate executives and staff managers.'],
+    ['11-1011.03', 'Chief Sustainability Officers', 'Communicate and coordinate with management, shareholders, customers, and employees to address sustainability issues. Enact or oversee a corporate sustainability strategy.'],
+    ['11-1021.00', 'General and Operations Managers', 'Plan, direct, or coordinate the operations of public or private sector organizations. Duties and responsibilities include formulating policies, managing daily operations, and planning the use of materials and human resources, but are too diverse and general in nature to be classified in any one functional area of management or administration, such as personnel, purchasing, or administrative services.'],
+    ['11-1031.00', 'Legislators', 'Develop, introduce or enact laws and statutes at the local, tribal, State, or Federal level. Includes only workers in elected positions.'],
+]
+
+
+class MockOnetSourceDownloader(object):
+    def download(self, *args):
+        with utils.makeNamedTemporaryCSV(occupation_content, '\t') as temp:
+            return temp
+
+
+@patch('algorithms.job_normalizers.esa_jobtitle_normalizer.ONET_VERSIONS', ['db_21_0_text'])
+def test_esa_normalizer():
+    normalizer = ESANormalizer(MockOnetSourceDownloader)
+    assert normalizer.normalize_job_title('Staffing Expert')[0]['title'] == 'chief executives'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 
 @contextmanager
 def makeNamedTemporaryCSV(content, separator=','):
-    tf = tempfile.NamedTemporaryFile()
+    tf = tempfile.NamedTemporaryFile(delete=False)
     with open(tf.name, 'w') as write_stream:
         writer = csv.writer(write_stream, delimiter=separator)
         for row in content:


### PR DESCRIPTION
I split the ESA Job Normalizer into two different parts to make it more easily testable: 
- The ONET Occupation grabber was moved to datasets.py. It's abstracted a little bit, and I can see us using it for other things.
- The normalizer itself, which now doesn't have any downloading code.

The latter part is what I'm more interested in testing. When controlling the ONET occupation list to a handful of occupations, it was easy to see what concepts were being extracted from the descriptions, and I just made up a job title that matched one of them well.