### PR TITLE
Fix job title first pass cleaning [Resolves #26]

### DIFF
--- a/dags/geo_title_counts.py
+++ b/dags/geo_title_counts.py
@@ -44,7 +44,7 @@ class GeoTitleCountOperator(BaseOperator):
         )
 
         job_postings_generator = job_postings(s3_conn, quarter)
-        title_cleaner = NLPTransforms().lowercase_strip_punc
+        title_cleaner = NLPTransforms().title_phase_one
         counts, title_rollup = GeoTitleAggregator(title_cleaner=title_cleaner)\
             .counts(job_postings_generator)
 

--- a/tests/test_utils_nlp.py
+++ b/tests/test_utils_nlp.py
@@ -1,0 +1,10 @@
+from utils import nlp
+
+transforms = nlp.NLPTransforms()
+
+
+def test_title_phase_one():
+    assert transforms.title_phase_one('engineer') == 'engineer'
+    assert transforms.title_phase_one('engineer/apply now') == 'engineer apply now'
+    assert transforms.title_phase_one('engineer / apply now') == 'engineer apply now'
+    assert transforms.title_phase_one("macy's engineer / apply now") == 'macys engineer apply now'

--- a/utils/nlp.py
+++ b/utils/nlp.py
@@ -4,6 +4,7 @@ Shared Natural Language Processing utilities
 import unicodedata
 import re
 
+
 class NLPTransforms(object):
     # An object that performs common NLP transformations
     # for unicodedata, see:
@@ -33,15 +34,34 @@ class NLPTransforms(object):
             if not unicodedata.category(char)[0] in self.punct
         )
 
+    def title_phase_one(self, document):
+        """
+        Args:
+            document: A unicode string
+        Returns:
+            The document, lowercased, sans punctuation, whitespace normalized
+        """
+        no_apos = re.sub(r'\'', '', self.normalize(document))
+        strip_punc = ''.join(
+            char if not unicodedata.category(char)[0] in self.punct else ' '
+            for char in no_apos
+        )
+        return re.sub(r'\s+', ' ', strip_punc.strip())
+
     def clean_str(self, document):
         """
         Args:
             document: A unicode string
         Returns:
-            The array of split words in document, lowercased, sans punctuation, non-English letters
+            The array of split words in document, lowercased,
+            sans punctuation, non-English letters
         """
         RE_PREPROCESS = r'\W+|\d+'
-        document = re.sub( RE_PREPROCESS, ' ', self.lowercase_strip_punc(document))
+        document = re.sub(
+            RE_PREPROCESS,
+            ' ',
+            self.lowercase_strip_punc(document)
+        )
         document = re.sub(r"[^A-Za-z0-9(),!?\'\`]", " ", document)
         document = re.sub(r"\'s", " \'s", document)
         document = re.sub(r"\'ve", " \'ve", document)


### PR DESCRIPTION
In first pass title cleaning,
- strip apostrophes
- replace other punctuation with space
- Squash whitespace blocks down to one space
- PEP8 cleaned rest of utils.nlp