### PR TITLE
Add ONET KSA distinctions to skills_master [Resolves #30]

### DIFF
--- a/api_sync/v1/alembic.ini
+++ b/api_sync/v1/alembic.ini
@@ -1,0 +1,65 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat alembic/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/api_sync/v1/alembic/README
+++ b/api_sync/v1/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/api_sync/v1/alembic/env.py
+++ b/api_sync/v1/alembic/env.py
@@ -1,0 +1,75 @@
+from __future__ import with_statement
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+from utils.db import get_apiv1_dburl
+from api_sync.v1.models import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+db_url = str(get_apiv1_dburl())
+config.set_main_option('sqlalchemy.url', db_url)
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    context.configure(
+        url=db_url,
+        target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/api_sync/v1/alembic/script.py.mako
+++ b/api_sync/v1/alembic/script.py.mako
@@ -1,0 +1,23 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/api_sync/v1/alembic/versions/d523e7e45456_added_ksa_type.py
+++ b/api_sync/v1/alembic/versions/d523e7e45456_added_ksa_type.py
@@ -1,0 +1,23 @@
+"""Added ksa_type
+
+Revision ID: d523e7e45456
+Revises: 
+Create Date: 2017-02-27 15:21:53.018866
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd523e7e45456'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('skills_master', sa.Column('ksa_type', sa.String))
+
+
+def downgrade():
+    op.drop_column('skills_master', 'ksa_type')

--- a/api_sync/v1/models/skills_master.py
+++ b/api_sync/v1/models/skills_master.py
@@ -11,16 +11,10 @@ class SkillMaster(Base):
 
     uuid = db.Column(db.String, primary_key=True)
     skill_name = db.Column(db.String)
+    ksa_type = db.Column(db.String)
     onet_element_id = db.Column(db.String)
     description = db.Column(db.String)
     nlp_a = db.Column(db.String)
-
-    def __init__(self, uuid, skill_name, onet_element_id, description, nlp_a):
-        self.uuid = uuid
-        self.skill_name = skill_name
-        self.onet_element_id = onet_element_id
-        self.description = description
-        self.nlp_a = nlp_a
 
     def __repr__(self):
         return '<uuid {}>'.format(self.uuid)

--- a/api_sync/v1/skills_master.py
+++ b/api_sync/v1/skills_master.py
@@ -9,12 +9,12 @@ def load_skills_master(filename, db_engine):
         reader = csv.DictReader(f, delimiter='\t')
         session = sessionmaker(db_engine)()
         for row in reader:
-            skill_master = SkillMaster(
+            session.merge(SkillMaster(
                 uuid=row['skill_uuid'],
                 skill_name=row['ONET KSA'],
+                ksa_type=row['ksa_type'],
                 onet_element_id=row['Element ID'],
                 description=row['Description'],
                 nlp_a=row['nlp_a']
-            )
-            session.merge(skill_master)
+            ))
         session.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ Sqlalchemy
 testing.postgresql
 psycopg2
 mock
+alembic

--- a/tests/api_sync/v1/input/skills_master_table.tsv
+++ b/tests/api_sync/v1/input/skills_master_table.tsv
@@ -1,398 +1,398 @@
-	O*NET-SOC Code	Element ID	ONET KSA	Description	skill_uuid	nlp_a
-255	11-3021.00	2.b.3.c	equipment selection	determining the kind of tools and equipment needed to do a job.	035d26f14c0274510816c4f07c8ce8f3	equipment selection
-259	11-3021.00	2.b.3.j	equipment maintenance	performing routine maintenance on equipment and determining when and what kind of maintenance is needed.	4b6e11c46579a9cebec51d9038c58d10	equipment maintenance
-261	11-3021.00	2.b.3.l	repairing	repairing machines or systems using the needed tools.	b452c459a4485c0e7fe1d71d79801f51	repairing
-94655	11-3021.00	43222625	access servers		2f36f12f543300d1b28997086c077112	access servers
-94656	11-3021.00	43211501	computer servers		a51637a0ff334ff6a4240dd341cec440	computer servers
-94657	11-3021.00	27113203	computer tool kits		23d38b13cc68e84e6f48861f23f3010d	computer tool kits
-94658	11-3021.00	43211501	file servers		3e3e2221a18f3dbd0ea57cf73dd516bc	file servers
-94659	11-3021.00	43201407	industry standard architecture/peripheral component interconnect isa/pci cards		081cf1f3cd5775b173df07b64e2f4922	industry standard architectureperipheral component interconnect isapci cards
-94660	11-3021.00	43212104	inkjet printers		bdbd5ae91409d60393ead1ea3e32c09e	inkjet printers
-94661	11-3021.00	43211501	internet information services iis servers		7e57e8b7544beac3aab463bd6643c7a3	internet information services iis servers
-94663	11-3021.00	43212105	laser printers		0783a67db63c96881d6fc06fee31f1e7	laser printers
-94664	11-3021.00	43211512	mainframe computers		ffef622c9a83001fb3ab45b55b743d3b	mainframe computers
-94665	11-3021.00	43211501	mid-range computers		eace00184ed6391bc93c0ac6c1e6ddc9	midrange computers
-94666	11-3021.00	43211501	minicomputers		474e29be277ca713600ac20f3679acce	minicomputers
-94667	11-3021.00	43211501	netware servers		6cbe4dfe6ffb728a26bf4c0a17808d6f	netware servers
-94668	11-3021.00	41113711	network analyzers		ae870e1ce33c8eb7aa804247201c35cc	network analyzers
-94669	11-3021.00	43201404	network interface cards nic		e29746535ea658f1130327b015ad732d	network interface cards nic
-94670	11-3021.00	43222609	network routers		ed85d0ff8d138169449f9bcfc51093d3	network routers
-94671	11-3021.00	43222612	network switches		9abd8938573eb706ed5b3af6f53e34fc	network switches
-94674	11-3021.00	43201537	print servers		2aab2c533b832ddc4e3bfd8d59361664	print servers
-94675	11-3021.00	27111505	punchdown tools		26d492ced12d681e26b26767d9be583a	punchdown tools
-94676	11-3021.00	43222627	robot automation tool		a83b2a2304f4c252e569d78c5379a4ac	robot automation tool
-94677	11-3021.00	27111701	screwdrivers		ce9e15625cabeb7bb31d702645b95ccb	screwdrivers
-94678	11-3021.00	43211501	storage servers		f55d7336a654ea3a3be9ad682fe014b3	storage servers
-94679	11-3021.00	43221522	teleconferencing equipment		ecff0767db74528e41734e0e01d0c06d	teleconferencing equipment
-94680	11-3021.00	43211501	web servers		f196462d0be07f3bcd139e427c6e691a	web servers
-94681	11-3021.00	43211502	workstations		b13379aba36cbcabfa27ff4841d28ca8	workstations
-94682	11-3021.00	43232303	act! software		355fea8c8105fa0e5cd7923dc5e61ef1	act software
-94684	11-3021.00	43232408	adobe systems adobe flex		19ff1371d91d5ed03aa2869b17325ce5	adobe systems adobe flex
-94685	11-3021.00	43232405	advanced business application programming abap		82a8948ebc48a0df829913235a385d59	advanced business application programming abap
-94686	11-3021.00	43232304	alphafour software		be5a8b5b62fbd218054e0a74777042ac	alphafour software
-94689	11-3021.00	43232304	apache pig		4c2819d1c90da1e5c6f8dfa7291d69e0	apache pig
-94690	11-3021.00	43232304	apache solr		51c185588a8b97e1813bc23ea51bd358	apache solr
-94691	11-3021.00	43232408	apache tomcat		b0bac281e1a992db7579705b348c5b20	apache tomcat
-94695	11-3021.00	43232110	apple iwork numbers		62f216af26f81befeb2742970eab1378	apple iwork numbers
-94696	11-3021.00	43232104	apple iwork pages		4626ac2c4fbd80908ddd55bc33715118	apple iwork pages
-94697	11-3021.00	43233004	apple macintosh os/x		fb0eefedbd8fe0d1b8839b9a321efacc	apple macintosh osx
-94698	11-3021.00	43232402	assembler		83fd5a089b5ebb6e9f93159c236dc320	assembler
-94699	11-3021.00	43231601	billing software		c668f63290031cc33f4054e5af00ade3	billing software
-94700	11-3021.00	43232306	blackboard software		f78b264fcc8f58958a8d44779a58001b	blackboard software
-94701	11-3021.00	43232405	borland paradox		76f1764fa30025e55baf596d2e9501f5	borland paradox
-94702	11-3021.00	43232402	c		4a8a08f09d37b73795649038408b5f33	c
-94703	11-3021.00	43232405	c++		6ce809eacf90ba125b40fa4bd903962e	c
-94704	11-3021.00	43232310	ca erwin data modeler		abbf2ec4498e2ca188757d6b7fbf4e4d	ca erwin data modeler
-94705	11-3021.00	43232909	cisco systems wan manager		367073e7d3f2e455407c741d70c3871e	cisco systems wan manager
-94707	11-3021.00	43232402	common business oriented language cobol		f3910fec4907c6459370ce69849d8abe	common business oriented language cobol
-94708	11-3021.00	43231513	corel office suite		f3915bc0887eefec4cb8f5e47dbc54a0	corel office suite
-94709	11-3021.00	43232313	customer information control system ccis		14556697d08d7457f4e0ea69bda4891e	customer information control system ccis
-94710	11-3021.00	43232801	dartware intermapper		ce816cc393ec711f9eae8830a8958edb	dartware intermapper
-94712	11-3021.00	43232408	dynamic hypertext markup language dhtml		0db059c4dd6ed3bbbaac64ee33279a47	dynamic hypertext markup language dhtml
-94714	11-3021.00	43232405	embarcadero delphi		b2467b81bbc94a7043e971740d61239a	embarcadero delphi
-94717	11-3021.00	43233204	firewall software		2c9e7547b6c759ea88978ae95ed7412d	firewall software
-94718	11-3021.00	43233001	ftp program software		6cf7b619a576ee85b145f0aaee24136a	ftp program software
-94720	11-3021.00	43231501	help desk software		5d0636cd96818b10d08d4162df24d5bc	help desk software
-94721	11-3021.00	43233004	hewlett packard hp-ux		491fdb8cbd2229f8ccd0750cefe5afc2	hewlett packard hpux
-94722	11-3021.00	43231505	human resource management software hrms		4527da9088257959d4a91722a48208b7	human resource management software hrms
-94723	11-3021.00	43232305	hyperion software		ab836ca261d968887d9e3734c76d53ae	hyperion software
-94726	11-3021.00	43232403	ibm infosphere datastage		06eeea0a85b24bf2084dea00c26e7891	ibm infosphere datastage
-94727	11-3021.00	43232915	ibm iseries access		d6a79003da68d6d1f69618381974dafe	ibm iseries access
-94729	11-3021.00	43232403	ibm websphere		6700aed160e6d0afb854bbe10071d834	ibm websphere
-94730	11-3021.00	43231602	infor erp baan		bdb8c0841d8feb79de88752dac3b90ea	infor erp baan
-94731	11-3021.00	43232312	iplanet web server software		28d52c4e30cf58d8722c968fd224b298	iplanet web server software
-94733	11-3021.00	43232402	k2 business process automation		912b1de107447746d826b23e538c4b9f	k2 business process automation
-94734	11-3021.00	43232905	lan software		2f99095dd34ebd4e6ae3b0b6b760673a	lan software
-94735	11-3021.00	43232306	langlais computer consultants calman		e5f9fffcf633cafc23847d525619c536	langlais computer consultants calman
-94736	11-3021.00	43233004	linux		e206a54e97690cce50cc872dd70ee896	linux
-94737	11-3021.00	43233501	linux-based email software		265e83633224bc5adabb9f2ab2da0abe	linuxbased email software
-94738	11-3021.00	43232901	mac helpmate		e5a71314f85b0a41d996ae9b68cd5907	mac helpmate
-94740	11-3021.00	43232402	microsoft .net framework		674301048ce0213f63863f2e3560fada	microsoft net framework
-94742	11-3021.00	43232408	microsoft active server pages asp		06fe645487690ce5db130dd6e4c08f07	microsoft active server pages asp
-94743	11-3021.00	43232303	microsoft business contact manager		6268c3a27a6f0255870e39310b49b828	microsoft business contact manager
-94745	11-3021.00	43232303	microsoft dynamics crm		a206bf3c78efe37bd31b5616e47dd153	microsoft dynamics crm
-94747	11-3021.00	43231602	microsoft dynamics nav		2ab4ba1cf5102653a0ed7f35ddfdd2b6	microsoft dynamics nav
-94748	11-3021.00	43232108	microsoft entourage		1383e4f69097f6fc405c8c385a428108	microsoft entourage
-94751	11-3021.00	43232107	microsoft front page		4389da80da3e9d7271ae3ef8cdd63fa6	microsoft front page
-94753	11-3021.00	43233503	microsoft office sharepoint server moss		1668117117bc5a95e8a47356af926648	microsoft office sharepoint server moss
-94759	11-3021.00	43232405	microsoft sql server reporting services ssrs		be21b9d0235988a87cd29a039ef2ce31	microsoft sql server reporting services ssrs
-94763	11-3021.00	43232402	microsoft visual basic scripting edition vbscript		99f365ebf0e9e7e8aa659d92bb029607	microsoft visual basic scripting edition vbscript
-94764	11-3021.00	43232311	microsoft visual foxpro		16a26fd8d978e4b77b190083a8c25b02	microsoft visual foxpro
-94765	11-3021.00	43232402	microsoft visual studio		8356f95d4bb62279fd99308dd36ed816	microsoft visual studio
-94766	11-3021.00	43232701	microsoft windows server		0374fbf910ff24f949526c1d1693dd46	microsoft windows server
-94769	11-3021.00	43232910	mobile wireless network infrastructure software		8048b6b72800432c9eb6d947721d8934	mobile wireless network infrastructure software
-94770	11-3021.00	43232304	mongodb		685a5f7cc75b4796f6c6e00ccd384f01	mongodb
-94773	11-3021.00	43232705	netscape navigator		98620c717bb2c63cdc142808860a0265	netscape navigator
-94774	11-3021.00	43232408	node.js		28a3689be95c88dd5e7a37db516ab084	nodejs
-94775	11-3021.00	43232304	nosql software		1962f3eb13f04aab14b76d00e09a16e8	nosql software
-94776	11-3021.00	43233002	novell network software		e566b9897fbc0e00faaaf8970210369f	novell network software
-94777	11-3021.00	43232405	objective c		3add2283d882284db4bca00242f32c0d	objective c
-94778	11-3021.00	43232314	oracle business intelligence enterprise edition		c9c14d4b8fd1587b65dd79badbc7cece	oracle business intelligence enterprise edition
-94779	11-3021.00	43232306	oracle dbms		10adae916fdaa6d2ba5980bb81a94f7b	oracle dbms
-94783	11-3021.00	43232405	oracle java		27f2b03acd8b8784acab5c5b60118070	oracle java
-94786	11-3021.00	43232304	oracle pl/sql		52f667e44a0668bca8f2a7075462897b	oracle plsql
-94787	11-3021.00	43231507	oracle primavera systems software		002958fd200aae9a5eaba67a796841ff	oracle primavera systems software
-94789	11-3021.00	43233004	oracle solaris		551185c96c3978a189d34ff0414ad3cf	oracle solaris
-94790	11-3021.00	43232701	oracle weblogic server		d9fe9e61e1989fa02d381ac9c30e9358	oracle weblogic server
-94791	11-3021.00	43233501	pegasus software		fc015ec322e8a477eedddddaa1f667ca	pegasus software
-94792	11-3021.00	43232303	performance solutions technology managepro		0f0adc0d04e05ec1d78f5d0c51097730	performance solutions technology managepro
-94794	11-3021.00	43232606	pilgrim software pilgrim smartsolve software		3e8e36ae4691e1829b1519f681762cb4	pilgrim software pilgrim smartsolve software
-94795	11-3021.00	43232312	plumtree software		06347d6dd49e1251689d8137a7aa5b0e	plumtree software
-94796	11-3021.00	43232311	postgresql software		6265067f488d81393ccd0776d8b205e8	postgresql software
-94797	11-3021.00	43232405	practical extraction and reporting language perl		0c366e96abe4377fb976e4121f84476e	practical extraction and reporting language perl
-94798	11-3021.00	43232402	progress openedge abl		d5d47ab628562b08f6f923aa2d459c9c	progress openedge abl
-94799	11-3021.00	43232701	progress openedge application server		c7479581e03e4a96359290b6f78b6afe	progress openedge application server
-94800	11-3021.00	43232304	progress openedge fathom replication software		0096bb83df55ea0ef961aefa3a995f25	progress openedge fathom replication software
-94801	11-3021.00	43232403	progress sonic esb		047d7dbdb9981ea952aecf08a3e49c17	progress sonic esb
-94802	11-3021.00	43232408	progress webspeed workshop		634730c99c08bfdc3b68ca9e83c59b89	progress webspeed workshop
-94803	11-3021.00	43232401	puppet		768747907b90c39ab6f16fcb3320897a	puppet
-94804	11-3021.00	43232405	python		23eeeb4347bdd26bfc6b7ee9a3b755dd	python
-94806	11-3021.00	43233501	qualcomm eudora		0af00188129732f851b01928b62fdcb5	qualcomm eudora
-94808	11-3021.00	43233004	red hat enterprise linux		b7958f6fcf3039fa7f9e8f375cb06bca	red hat enterprise linux
-94809	11-3021.00	43232701	red hat wildfly		ea90ad928d5acee910f9042bb98ed56d	red hat wildfly
-94810	11-3021.00	43232304	relational database management software		779c8394b38a9fe199596e21c9ef3c84	relational database management software
-94811	11-3021.00	43232408	ruby on rails		ec49dc5392817d11fb8e9f880985e981	ruby on rails
-94812	11-3021.00	43233001	samba		65575d0766c89ce103967995f76c41d2	samba
-94816	11-3021.00	43232804	solarwinds software		d6df4906c9289ab722d30432cafc29d5	solarwinds software
-94817	11-3021.00	43232606	sox cobit		0ee154fabce47245699d90d68e7e89ca	sox cobit
-94824	11-3021.00	43233001	symantec veritas file system		6272d40bc060e6caf73a94a1b25bba9c	symantec veritas file system
-94825	11-3021.00	43233001	symantec veritas volume manager		92ef6faf7b73d2cbd10c59d58020b5ce	symantec veritas volume manager
-94827	11-3021.00	43232911	telnet programs software		d6f1e0701defd0b1ebd533b51e006e05	telnet programs software
-94829	11-3021.00	43232605	the mathworks matlab		68bdaa4f3e4c787fc731e50fa0690837	the mathworks matlab
-94830	11-3021.00	43232404	tk software		2f3e04e822b24eba16d7780d3d377d89	tk software
-94831	11-3021.00	43232407	unified modeling language uml		3a09f6720c5935f75bd10aa819d4b767	unified modeling language uml
-94832	11-3021.00	43233004	unix		4913a9178621eadcdf191db17915fbcb	unix
-94833	11-3021.00	43233415	veritas netbackup		dcb585b233b8ff6042ce65acd759679f	veritas netbackup
-94834	11-3021.00	43233204	virtual private networking vpn software		8cd20f6799b263a29e42c77d9c357f94	virtual private networking vpn software
-94835	11-3021.00	43232911	zephyr extra! terminal emulation		1381136ff9737baecfde419afab7d5ad	zephyr extra terminal emulation
-94842	11-3031.01	43231602	aderant expert back office, powered by keystone		61865b285c412887ecc272d520d81c06	aderant expert back office powered by keystone
-94843	11-3031.01	43231601	automatic data processing easypay software		46956a66a2dca6018f34e63f46534185	automatic data processing easypay software
-94844	11-3031.01	43231505	automatic data processing pc payroll for windows pcpw		a92d3401f0e8fcba9396790c438eeb56	automatic data processing pc payroll for windows pcpw
-94845	11-3031.01	43232110	corel quattropro		36e9ae1c9d3dd348cf8353d824c53ba9	corel quattropro
-94846	11-3031.01	43231602	deltek software		6c1af0e9471c4d8bc18774a0d10bcf7b	deltek software
-94847	11-3031.01	43231602	exact software macola es		da53dcdd787ea7f9babe71dbe2461aa8	exact software macola es
-94848	11-3031.01	43231604	frx software		e03b53012075afc6e2ac574f67757d84	frx software
-94850	11-3031.01	43231601	hyperion enterprise		abb5e9f8131fd3218afc0ea77a83cf28	hyperion enterprise
-94851	11-3031.01	43231604	hyperion pillar software		8c4530997c0a39c1a0b5c6363af3b089	hyperion pillar software
-94852	11-3031.01	43231602	hyperion solutions system 9 planning		372f14c0da0b2102ea41afe5fcd11fac	hyperion solutions system 9 planning
-94855	11-3031.01	43232110	ibm lotus 1-2-3		c388f4e7a6a3aa22e0f068b0100c0c08	ibm lotus 123
-94856	11-3031.01	43231602	infor erp syteline		2b6ea855cfc2b6b5913b1c5252776ccb	infor erp syteline
-94858	11-3031.01	43231601	job costing software		051e6a8f91ad4dd5f19f46e38f8c280d	job costing software
-94867	11-3031.01	43231601	myob premier accounting small business suite		2c687d02fb18cd1aa7d6e402ed3e11f4	myob premier accounting small business suite
-94871	11-3031.01	43231602	oracle peoplesoft		60779fe326229564ed5c87f240eb7be6	oracle peoplesoft
-94872	11-3031.01	43231602	oracle peoplesoft financials		fab8ec2b7fd886d572b3818839354e84	oracle peoplesoft financials
-94875	11-3031.01	43231601	sage fixed asset solution fas		c845f700a68b89c1c4be950850d69acc	sage fixed asset solution fas
-94876	11-3031.01	43231601	sage mip fund accounting		4a5a7318d290bb6e5ad876bde64d0d15	sage mip fund accounting
-94879	11-3031.01	43231602	solomon software		d3352972e16adcc44dd28cb6a50b1ad8	solomon software
-94888	11-3031.02	43231601	accounts receivable software		5a3a426d3afcf0262387a5890ea0326a	accounts receivable software
-94889	11-3031.02	43231604	ares corporation prism project estimator		00cd9c36bf69b0835942d5769dfcec26	ares corporation prism project estimator
-94890	11-3031.02	43231604	credit management software		c29f209ae6cf5146f91bb18b79b7d195	credit management software
-94896	11-3031.02	43232705	internet browser software		5d2a0bfc9e4001497f692841e2182c84	internet browser software
-94908	11-3031.02	43232110	moody's kmv famas		3e48ef7dd755bf8e280cd919fdd159b9	moodys kmv famas
-94924	11-3031.02	43232104	word processing software		dc46d4596698ec0cc7dfda998a74e3bf	word processing software
-94926	11-3051.00	24101603	forklifts		d9d11d4f119ab7e7d29f26bff90390df	forklifts
-94931	11-3051.00	27111803	squares		192ba166b3957ab1020e9a72ea1b40ed	squares
-94933	11-3051.00	27111801	tape measures		10ec7e921659ddd3600cb26749054510	tape measures
-94934	11-3051.00	41111648	taper gauges		e5a733614bd644a441b7edfb1017b9e9	taper gauges
-94935	11-3051.00	41111621	vernier calipers		641ae6a08800e6ae1b32d033a0c7815a	vernier calipers
-94936	11-3051.00	43232603	abb optimize software		c8dd1827b58f78a3e8a0418d97fbcf4c	abb optimize software
-94942	11-3051.00	43232604	autodesk autocad		9c4d7d28b2f883d41c580778012a2f13	autodesk autocad
-94943	11-3051.00	43232608	citect iim		264f5d3e39f07087a4f73e27b626a1f1	citect iim
-94944	11-3051.00	43232608	citectscada reports		70ca77a375a2925d7c75737dea87eae5	citectscada reports
-94945	11-3051.00	43232608	citectscada software		c1eafec5f20ae14d3a615e96f9c3478a	citectscada software
-94946	11-3051.00	43231505	clockware software		491c06cf01b2fb8bef610cbb486698af	clockware software
-94947	11-3051.00	43232604	computer aided design cad software		1508af139d359641efcfdbfb616bbfcb	computer aided design cad software
-94948	11-3051.00	43232108	computer integrated manufacturing cim software		1f1bfbebd9adbb13bb413d0a31835204	computer integrated manufacturing cim software
-94949	11-3051.00	43231505	computer integrated manufacturing cim time manager software		b7b8f860f5a522276fdc49d00334fcdb	computer integrated manufacturing cim time manager software
-94950	11-3051.00	43231508	computer integrated manufacturing cim warehouse shipping manager software		46d9aa6f4101df3dff488fb8af0690f1	computer integrated manufacturing cim warehouse shipping manager software
-94951	11-3051.00	43232104	corvu software		8e335771d97b54916e6c6cbac83d3ba6	corvu software
-94953	11-3051.00	43231505	employee performance management software		67205951a4e21482397c91eb3d7d16c9	employee performance management software
-94954	11-3051.00	43232306	exact software jobboss		b0d6626e3e01b909588420b047f53e4a	exact software jobboss
-94956	11-3051.00	43231604	financial planning software		e8011ee860fcf0326ff469250f0b3086	financial planning software
-94957	11-3051.00	43232402	ibm rational clearquest		f0ef5799896729f514d05d38f642a90f	ibm rational clearquest
-94958	11-3051.00	43232608	industrial production manager and stock control software		f8bbf7e62cfdcd8482d2279d7dd3aa87	industrial production manager and stock control software
-94959	11-3051.00	43231601	intuit quickbooks manufacturing & wholesale software		9a9477076396783adb1e084e4190ccdc	intuit quickbooks manufacturing  wholesale software
-94960	11-3051.00	43232608	marel production system mps software		8ee03b234047b90cf0a7136b967daa61	marel production system mps software
-94970	11-3051.00	43232603	plant management software		921d80412cfe3d6ead46d908a59e877e	plant management software
-94971	11-3051.00	43231602	processpro premier		14b3470e2cfe6085f378c2d29a664454	processpro premier
-94972	11-3051.00	43232608	prosys software		a780ac63da1ca6603274cdf656f2a411	prosys software
-94973	11-3051.00	43232202	qumas software		02b511f7123ebcfa4901ffe0cbcd896f	qumas software
-94974	11-3051.00	43231508	sap inventory software		9c8188d270b1d0a696bdf26e4f01b169	sap inventory software
-94976	11-3051.00	43232306	scadex technologies maestro		6651f028b4f7b61275251ea5613518bc	scadex technologies maestro
-94977	11-3051.00	43232608	statistical process control software		d7d8839b7f7adfdcbc80beacd82e8500	statistical process control software
-94978	11-3051.00	43232608	wonderware dt analyst plant productivity improvement software		040653e3cc354c357e7858dea0a7432f	wonderware dt analyst plant productivity improvement software
-94979	11-3051.00	43232108	workschedule software		2b3f17d1ca6ea2813a031ddd65c8f5bd	workschedule software
-94980	11-3051.01	41121502	automated diluters		1ba9360609bc1592ed19bee4371c5af3	automated diluters
-94981	11-3051.01	41113037	automated microplate elisa readers		4acbd0210ff327e580066a40c9a0cf72	automated microplate elisa readers
-94982	11-3051.01	41115819	cellular assay equipment		1f8d627372fbc8c3aa3ea0c68f8ef007	cellular assay equipment
-94983	11-3051.01	43212104	computer inkjet printers		dbd58b58eacd3fcd35ed74ee02231951	computer inkjet printers
-94984	11-3051.01	41105307	electrophoresis equipment		14aa62071fafc1e3bd91a4f219c4bdd9	electrophoresis equipment
-94985	11-3051.01	41115408	fourier transfer infrared ftir spectrometers		cb77fd78c3f21c3ac52de8a30055cdad	fourier transfer infrared ftir spectrometers
-94986	11-3051.01	41115703	gas chromatography equipment		0e1820db1126c3138a53aa9281d89583	gas chromatography equipment
-94987	11-3051.01	43211715	handheld data collectors		a4d0bd9af457aeac96151ccb77fba77a	handheld data collectors
-94988	11-3051.01	41115403	infrared spectroscopic equipment		ba2de37bb31db6d6b795596018be1736	infrared spectroscopic equipment
-94989	11-3051.01	41111517	laboratory analytical balances		f258e5beb7f11c18bfb92bc66a1bc199	laboratory analytical balances
-94990	11-3051.01	41103903	laboratory benchtop centrifuges		cd5b525b5c8c12edc8150d432b91aeea	laboratory benchtop centrifuges
-94991	11-3051.01	41104806	laboratory extraction equipment		9bb66ac25ef52c84818a173bda028f4a	laboratory extraction equipment
-94992	11-3051.01	41111513	laboratory moisture balances		5d86198ea315b8071ecbdc7db86e12cd	laboratory moisture balances
-94994	11-3051.01	41115705	liquid chromatography equipment		8ff296900c8f0a06121394303a28727a	liquid chromatography equipment
-94996	11-3051.01	41115603	ph analyzers		c9481f0fcfb4d1fba2940e428d5dc2b9	ph analyzers
-94997	11-3051.01	41115602	titrators		8f25f9ef67ca7d970663071a0432d468	titrators
-94999	11-3051.01	43232608	asi datamyte gagemetrics		b4183ce3d10f92bf87628f25d3f81260	asi datamyte gagemetrics
-95000	11-3051.01	43232608	asi datamyte qda software		94f968e030143c2ed65bc73700f6f313	asi datamyte qda software
-95001	11-3051.01	43232608	asidatamyte datametrics		d9bff4fcc9166db62b4c1af40c4749db	asidatamyte datametrics
-95002	11-3051.01	43232608	cama software quality collaboration by design software		958e001030a5f6fcdaaffd54e62b5d04	cama software quality collaboration by design software
-95003	11-3051.01	43232608	cebos mq1 software		0ba66a98a8381c804fdee742481488ea	cebos mq1 software
-95004	11-3051.01	43232605	computing solutions labsoft lims		7ac03f43ed30052a644c1fb783d079e1	computing solutions labsoft lims
-95005	11-3051.01	43232605	core informatics laboratory information management system lims software		def17ba0c134d4823c7eac93a9a26690	core informatics laboratory information management system lims software
-95006	11-3051.01	43232606	etq reliance software		5c85a7d492d63130a15b2f53afbebca0	etq reliance software
-95008	11-3051.01	43232306	harrington group caweb software		189bc87a70fe4d6172aea34ca706cf0d	harrington group caweb software
-95009	11-3051.01	43232608	harrington group hqms software		ecb5b02afbff042f1c5156110e6daac9	harrington group hqms software
-95010	11-3051.01	43232406	hewlett packard loadrunner		20bcb70c57f0bb56f48ca1abc6c56368	hewlett packard loadrunner
-95011	11-3051.01	43232605	illumina laboratory information management system lims software		56d8c4e5653addfcd942e35527ddabe7	illumina laboratory information management system lims software
-95012	11-3051.01	43232608	infinity qs proficient software		fe5a181a44a590f3f4930b65e9096935	infinity qs proficient software
-95013	11-3051.01	43232605	lablite laboratory information management systems lims software		b7cab97f6f3e19b51c296624188077f6	lablite laboratory information management systems lims software
-95014	11-3051.01	43232608	laboratory automated quality control systems laqc software		fbe7fdec5bb45d97845f83b51d50af04	laboratory automated quality control systems laqc software
-95015	11-3051.01	43232605	labvantage solutions lims		78c70edec88119dc9ea895b458212e55	labvantage solutions lims
-95017	11-3051.01	43232606	mastercontrol software		01102bb9b423bdf4bf6b242e40b533d0	mastercontrol software
-95028	11-3051.01	43232605	pearson education phstat2		535590a82fad68401c7c46d1c277f23a	pearson education phstat2
-95029	11-3051.01	43232608	pq systems chartrunner lean		d8da5875239948298f5888a535168f59	pq systems chartrunner lean
-95030	11-3051.01	43232608	pq systems gagepack		065c156756542bb61b4bf53a7d6038cd	pq systems gagepack
-95031	11-3051.01	43232608	pq systems measurespy		addbc1e22d88612a36e42fb14bb8e898	pq systems measurespy
-95032	11-3051.01	43232605	pq systems sqcpack		45596433b488fd6b61bface90c381d0d	pq systems sqcpack
-95033	11-3051.01	43232605	promium element datasystem lims		e81e4e0161127f0a4c95ea314345b0c9	promium element datasystem lims
-95034	11-3051.01	43232605	quality systems international winlims		633ca03cf7444a31b682f47030ad8a33	quality systems international winlims
-95036	11-3051.01	43232606	sparta systems trackwise		7e31d578429bc1e9d35dec64fdde3b83	sparta systems trackwise
-95037	11-3051.01	43232605	starlims software		2a8983aaadf10f1db007cc406870c6b6	starlims software
-95038	11-3051.01	43232605	statgraphics software		7d4238179f2aebdb8251644885e8b2b9	statgraphics software
-95040	11-3051.01	43232605	systat software lisa.lims		7086a0d2f3f3feac620eeddb388003b9	systat software lisalims
-95041	11-3051.01	43232605	thermo fisher scientific laboratory information management systems (lims) software		80894a4e01dcd5d5d08015ccd00c302a	thermo fisher scientific laboratory information management systems lims software
-95042	11-3051.01	43232608	vivaldi software vivaldi quality management software		7232aa38be05ff95b8fd4279dcb95766	vivaldi software vivaldi quality management software
-95044	11-3051.02	43211715	dataloggers		b2b6e99ef01d9e10f5104a8788cef090	dataloggers
-95046	11-3051.02	26111601	diesel-powered generators		b519756cc711ab83d6113f5f70fee2e1	dieselpowered generators
-95049	11-3051.02	40151510	large volume water pumps		baa2ea9b470d69549a4c0a0f0e7bff9e	large volume water pumps
-95050	11-3051.02	24101623	material moving cranes		c11d4ad5640047c558b7c5011fe6ba02	material moving cranes
-95051	11-3051.02	43191510	mobile radios		4b8886f10d8705a9dc555099a6853697	mobile radios
-95054	11-3051.02	32101628	programmable logic controllers plc		a8972632d229ff660f529dd9ff59d9f5	programmable logic controllers plc
-95056	11-3051.02	43232306	datalogging software		b1bb6de5a9f4cc682b19b1efec306940	datalogging software
-95057	11-3051.02	43232306	infostat rimbase		f5d5ea4d35bc7b3d999f8328e01ec152	infostat rimbase
-95064	11-3051.03	41104008	air monitoring equipment		ba3efca8a47535be32a4c28f31338f3a	air monitoring equipment
-95065	11-3051.03	40141607	ball valves		1944870a1d05bd0bc52feead0c005b3d	ball valves
-95066	11-3051.03	24101712	belt conveyor systems		17c32004fd6fc782d656c1a3303092d0	belt conveyor systems
-95068	11-3051.03	46182002	dust and particulate respirators		922387afa5ad915d55c332d0f82ec1b7	dust and particulate respirators
-95069	11-3051.03	46171603	electric timing devices		c41dec036d663e22b39194c9dc20321e	electric timing devices
-95070	11-3051.03	46171604	emergency alarm systems		7b5bcb5108495f16505848ef9d91bfc0	emergency alarm systems
-95071	11-3051.03	41104301	fermentation processing vessels		74c678ef999fe9b217ba05c0abb23a18	fermentation processing vessels
-95072	11-3051.03	40141609	flow control valves fcv		81cc59247660ae636c92845b6e1c5ced	flow control valves fcv
-95074	11-3051.03	40141613	gate butterfly valves		eb0963428b20e28b5e0745ef73cbb7cb	gate butterfly valves
-95075	11-3051.03	41121805	glass graduated cylinders		bb5bb674c00df49fc89844dd9ce27d5b	glass graduated cylinders
-95076	11-3051.03	41104501	gravity convection ovens		1aacb52da07cc68bdac56e4a35ba6a3e	gravity convection ovens
-95077	11-3051.03	40151506	hand sampling pumps		c46989784fd2bb1a20a6bff8352b2fa4	hand sampling pumps
-95078	11-3051.03	47131905	hazardous material spill kits		7ea58344ec7cb87f63367773d778db9e	hazardous material spill kits
-95080	11-3051.03	41112304	moisture analyzers		3f2b17e75a67f8c3311a58eba955edd5	moisture analyzers
-95081	11-3051.03	41105003	mole sieves		ecb3afe1c3f44dbca7a3aabf33b969cc	mole sieves
-95083	11-3051.03	41115603	ph probes		e5b1e1eee1aefca45bca16e117771bf1	ph probes
-95084	11-3051.03	41121804	reaction flasks		9c54fd6360118f4b60a885aa14315dca	reaction flasks
-95085	11-3051.03	41104015	sample ports		4b6169a0efe7904e6c3ab1485062bec1	sample ports
-95086	11-3051.03	46182004	self-contained breathing apparatus		730d20401cd16318026c248cbe9cc3f1	selfcontained breathing apparatus
-95087	11-3051.03	40141611	stop valves		ba87bbd29a4dd2ca4cc70cb2bb1ba8cb	stop valves
-95088	11-3051.03	40141609	throttle control valves tcv		67e82d02a3bc0685553f3d42ea0a56b7	throttle control valves tcv
-95090	11-3051.03	43232603	computerized maintenance management system cmms software		9db25b1044cb1133f99818b9497055b3	computerized maintenance management system cmms software
-95091	11-3051.03	43232608	distributed control systems dcs software		bcd4ac0ca710985cc1d9d5315bc8287d	distributed control systems dcs software
-95092	11-3051.03	43232108	employee scheduling software		0af814e7726201706e636143fb452394	employee scheduling software
-95093	11-3051.03	43232608	human machine interface hmi software		3cb1bc5763299f9f2b1dccceb94b6267	human machine interface hmi software
-95094	11-3051.03	43231508	inventory control software		1bb70d55351190ba55e21d36d31fddca	inventory control software
-95101	11-3051.04	40102001	biomass boilers		eaa6c022055113655ce77cd75cd7f5d0	biomass boilers
-95102	11-3051.04	40102001	bubbling fluidized bed boilers		9c6f151dbbbc59aae792896cc5c5a6ba	bubbling fluidized bed boilers
-95103	11-3051.04	40102001	circulating fluidized bed boilers		ba458e9ed7f94a5c3eacd5623ddfe2b9	circulating fluidized bed boilers
-95104	11-3051.04	40101703	cooling towers		890d1f8c7ef2e26f8712d315885965a0	cooling towers
-95106	11-3051.04	26111608	heat recovery steam generators		9ee3a00d90a73f632a690572b3a8222a	heat recovery steam generators
-95109	11-3051.04	24101708	radial stackers		ecb3e8923a1cebaeb4425c6c1a9d9131	radial stackers
-95110	11-3051.04	40102002	steam boilers		cb78fe5c3ee5dec93fdbe9b3df04a92f	steam boilers
-95111	11-3051.04	26101505	steam turbines		412264a0ee3b07e40d0dcf298c825160	steam turbines
-95112	11-3051.04	41104007	water samplers		6adef2d5798942c43aac734cbe311745	water samplers
-95113	11-3051.04	22101715	wood feed systems		f8e69a5ef0343444dd9e2beb8d28e92b	wood feed systems
-95124	11-3051.05	41104008	air samplers		2526fc60bdd044b89a6e7d4c71f40208	air samplers
-95125	11-3051.05	25101905	all terrain vehicles atv		175ac3812e312e9f1aa7d4cd34d21b24	all terrain vehicles atv
-95126	11-3051.05	26131701	combustible gas monitors		c9531c6ad03d00bb24e752c0867b7318	combustible gas monitors
-95128	11-3051.05	26111601	diesel reciprocating engine generator sets		22c800c817480044429ff94fc781c451	diesel reciprocating engine generator sets
-95129	11-3051.05	26131608	enclosed flares		66fa961b669d916d43d92b046497b62b	enclosed flares
-95130	11-3051.05	46171613	gas leak detectors		73f0d31efaa4e202347d4042f1a1019d	gas leak detectors
-95131	11-3051.05	26111604	gas reciprocating engine generator sets		4d2bf755c1c35bf639d432b26e2ce931	gas reciprocating engine generator sets
-95132	11-3051.05	41114401	micro anemometers		1826e4f13d57e25999b13dd93e4d37b4	micro anemometers
-95133	11-3051.05	41113118	multiple gas monitors		e1837652cd805c242ee63f7e469c258d	multiple gas monitors
-95135	11-3051.05	26131608	open flares		509fc5e6b1a99e76bb5c89815e6c1441	open flares
-95136	11-3051.05	41113110	oxygen analyzers		422c6d205a51532a95d258099d08c46d	oxygen analyzers
-95138	11-3051.05	41111927	pressure gauges		babb42bced21d09b0d28c39415ce856e	pressure gauges
-95139	11-3051.05	40141604	pressure valves		01cf46d2c9fcd5819857856a2d9ee20d	pressure valves
-95140	11-3051.05	25101507	utility trucks		78d4b92e043a8233bfa0344c90f745f3	utility trucks
-95145	11-3051.05	43232605	landfill gas analysis software		5d3398bf8cb4538710b6b86c1ec1dab4	landfill gas analysis software
-95146	11-3051.05	43232605	landtec system software lfg pro		4ceb5ad8de1c27a792ca66dfe3663191	landtec system software lfg pro
-95152	11-3051.05	43231602	worktech maximo		9e3cbe5df49b852ef526f1adb256daf2	worktech maximo
-95153	11-3051.06	40142207	dam water flow controls		40c241e059fbc3ae17aa0ffaf1164e3f	dam water flow controls
-95155	11-3051.06	39121601	electrical circuit breakers		f8e58ede92be7c23080d2b8978ad08d9	electrical circuit breakers
-95156	11-3051.06	26131808	electrical switch gear		ed8806414b15831811f9835693d5bd0e	electrical switch gear
-95157	11-3051.06	26111606	hydraulic power generation equipment		4b3d9ffd878e7cf7ef698a2410abea54	hydraulic power generation equipment
-95158	11-3051.06	26131803	hydroelectric power generator controls		df5b3d0216a85152a1b10308c39db09a	hydroelectric power generator controls
-95159	11-3051.06	26101506	impulse turbines		783db8362956d3da2e4e0ce919779722	impulse turbines
-95163	11-3051.06	39121002	power transformers		3116dcd7c3f7b7bb6ec5fb0d5e521bc6	power transformers
-95164	11-3051.06	46181902	protective ear muffs		85c4a2141b644599e0107d96b24a451f	protective ear muffs
-95165	11-3051.06	46182002	protective respirators		aa5cdc7c2bf10236fadb560b660bcc64	protective respirators
-95166	11-3051.06	26101506	reaction turbines		654e8d0a36115ac3731f63c227880f29	reaction turbines
-95167	11-3051.06	46181802	safety glasses		36647620d781132d4d337f3c162fbb93	safety glasses
-95168	11-3051.06	26101506	turbine generators		cb6fad1cfa0641e9d63affbfdaf03957	turbine generators
-95178	11-3051.06	43232608	supervisory control and data acquisition scada software		8308afefad6807aa299dda26f954db72	supervisory control and data acquisition scada software
-95182	11-3061.00	43231503	ariba spend management suite		0421a28bf853727d8bc7e53d19d32dc2	ariba spend management suite
-95183	11-3061.00	43231503	automated purchase order software		23979feae7812aa7e35634b949c3b70c	automated purchase order software
-95184	11-3061.00	43231503	bottomline technologies bottomline sprinter purchasing manager		05d545cf4be8349e1f307a3bd99d0736	bottomline technologies bottomline sprinter purchasing manager
-95185	11-3061.00	43231602	bowen & groves m1 erp		83a3c72ddcadef1b9971a84a3289d392	bowen  groves m1 erp
-95186	11-3061.00	43232306	corel paradox		154e10dc9dd7506b921630a15533a7ae	corel paradox
-95189	11-3061.00	43231602	epicor vantage erp		3e26e4b34368292b25722915ee660e3a	epicor vantage erp
-95191	11-3061.00	43231506	infor lawson supply chain management		439c1565ba5b6b2132eb64f43b0520b0	infor lawson supply chain management
-95193	11-3061.00	43231506	material requirement planning mrp software		7d3a633257c042128d2ec857b52e5d7a	material requirement planning mrp software
-95206	11-3061.00	43231604	oracle peoplesoft enterprise financial management solutions		ad59642d99ee06e38d170585dec795ed	oracle peoplesoft enterprise financial management solutions
-95207	11-3061.00	43231507	oracle primavera p6 enterprise portfolio project management		af8eccb773f72a0dac2cc029a2d3f4aa	oracle primavera p6 enterprise portfolio project management
-95209	11-3061.00	43231503	purchasing software		66a4f43ab5ec77084fb91bbb0de71dda	purchasing software
-95210	11-3061.00	43231503	purchasingnet eprocurement		afe02e7138ecc5fb94ef7e9a56f500c4	purchasingnet eprocurement
-95215	11-3071.01	43211701	barcode scanners		6f38c3959f94c686deeea72200d735ba	barcode scanners
-95216	11-3071.01	55121608	barcoding labels		39b9fd75a800535e2e59ac02aa7f57d9	barcoding labels
-95222	11-3071.01	43221721	radio frequency handheld terminals		6205d4c4639a6cfe39d8530b50b293a9	radio frequency handheld terminals
-95223	11-3071.01	43211710	radio frequency identification rfid devices		955b6c67c28dbfa235674cccd245a67c	radio frequency identification rfid devices
-95224	11-3071.01	43221721	radio frequency truck-mounted terminals		c479890e04b9b1992120d3e9b16dbf25	radio frequency truckmounted terminals
-95225	11-3071.01	43223209	wireless communication and satellite positioning tools		ca834c359e1ee4f15e9b6ce4bf802de1	wireless communication and satellite positioning tools
-95226	11-3071.01	43231510	abol manifest systems		18a4c2a01e014b4dd61203f1fad31615	abol manifest systems
-95227	11-3071.01	43232306	airline global distribution system gds software		b76e89fa0c914e38d27c4a6cf9156288	airline global distribution system gds software
-95228	11-3071.01	43232504	alk technologies fleetsuite		8a82d33bc4cab3170ac158996902e6e1	alk technologies fleetsuite
-95229	11-3071.01	43232504	alk technologies pc*miler		c8b2407ab405a34a6cc7042e1f23f80d	alk technologies pcmiler
-95230	11-3071.01	43231506	amber road software		3e9e492eafd54413bdc20cbc12c71d33	amber road software
-95231	11-3071.01	43231601	argos software abecas insight freight management system fms (accounting feature)		dfd9c5e2b99ec5db528f971d864fabf0	argos software abecas insight freight management system fms accounting feature
-95232	11-3071.01	43232108	argos software abecas insight freight management system fms (calendar and scheduling feature)		1ee2ffb9d0cd755582687f35104469f6	argos software abecas insight freight management system fms calendar and scheduling feature
-95233	11-3071.01	43231601	automated expense reporting system software		ecfd210c138d24ba86630b147c6ed5b1	automated expense reporting system software
-95234	11-3071.01	43232306	bentley transportation data manager		72c1ac829488e78524689b26180fe9dd	bentley transportation data manager
-95235	11-3071.01	43231506	cadre technologies cadence transportation management system		1df452e6e139d9a119327b0b86d7aa37	cadre technologies cadence transportation management system
-95236	11-3071.01	43232504	copilot truck		7a0d515519124ff700209ae8be11872a	copilot truck
-95237	11-3071.01	43232605	eaton fleet advisor		a8dc4a273d7081855b5407edb17a2bf6	eaton fleet advisor
-95239	11-3071.01	43231506	fleetware software		fd2f10eb2d149de08b7d463bb006e675	fleetware software
-95240	11-3071.01	43232605	freight rail crew optimization scheduling frcos software		6e7ff676d9ca898d457c9c342203fea1	freight rail crew optimization scheduling frcos software
-95241	11-3071.01	43231506	geometrix		b56d71d52ac96df160d816b7a14a2f4f	geometrix
-95242	11-3071.01	43232102	graphics software		5d1fa103ef1e9561b0c13afb1c7b9326	graphics software
-95243	11-3071.01	43231506	ibm i2 transportation manager		6026ff992f2fc47bd13033533fe0ef46	ibm i2 transportation manager
-95245	11-3071.01	43232605	imsure solutions shipflex		3a47994e5a10fac62c6f5cfb14299131	imsure solutions shipflex
-95246	11-3071.01	43231506	infosite technologies dispatch-mate		8b8e90676c965d0f2bf1078df230d95c	infosite technologies dispatchmate
-95247	11-3071.01	43231506	integrated decision support corporation expert fuel		50c0d991d8a22ef2072fcba845c68738	integrated decision support corporation expert fuel
-95248	11-3071.01	43231506	integrated decision support corporation netwise supply chain		3a34a7d517050a25b074023467f5a487	integrated decision support corporation netwise supply chain
-95249	11-3071.01	43232504	integrated decision support corporation route advice		67b593d6ddd6bc1c0208ae77155efa91	integrated decision support corporation route advice
-95250	11-3071.01	43231506	integrated decision support corporation swap advice		cee08e08011f7ce2a17ee108c48bb6eb	integrated decision support corporation swap advice
-95251	11-3071.01	43232605	integrated decision support match advice		21f9443d4cd3097abfe24908f5bbfddc	integrated decision support match advice
-95252	11-3071.01	43232605	integrated decision support netwise enterprise		2a674a3962e5662debe6b13d13502b84	integrated decision support netwise enterprise
-95253	11-3071.01	43232605	integrated decision support netwise frontline		e379c833c3a9c6b7181a20a48265226a	integrated decision support netwise frontline
-95254	11-3071.01	43232504	intergraph geomedia transportation manager		32b281d69aad9ac2e891656faa9c80f5	intergraph geomedia transportation manager
-95255	11-3071.01	43231508	international business systems software		d94420a4be7f5858e1811fdfbaeeeb1f	international business systems software
-95256	11-3071.01	43232306	labelmaster software reg-trieve		65760813c2ba3a935ebfe9482757627a	labelmaster software regtrieve
-95265	11-3071.01	43232605	qualcomm qtracs		efab0bce087c82486527a6ad4d702536	qualcomm qtracs
-95266	11-3071.01	43232605	qualcomm viaweb		11ccfe8718f3d405023d3c3bb29baccb	qualcomm viaweb
-95268	11-3071.01	43232606	scanlon associates logpak		770ff6e1f4cfee1b024fdb8725990b6b	scanlon associates logpak
-95269	11-3071.01	43232606	shipping solutions software		577e1e0f2d39a6755549f83cad166b37	shipping solutions software
-95270	11-3071.01	43232110	spreadsheet software		72dda444bdc23d4873055a8641c11428	spreadsheet software
-95272	11-3071.01	43231506	summary systems fleet commander		9573f479ab288aea6c6262259048b7d9	summary systems fleet commander
-95273	11-3071.01	43231506	supply chain event management software		5382d6b1742e918c08bdcf5f71b430ee	supply chain event management software
-95274	11-3071.01	43231602	tmw powersuite		ae585291c0c0412cfa51cbdfd3a72e4d	tmw powersuite
-95276	11-3071.01	43231605	workforce software empcenter time and attendance		f8313424d559fd061034b0a02a8ffcda	workforce software empcenter time and attendance
-95283	11-3071.02	25173107	global positioning systems gps		bbcb58429df0de339eeda241196b7972	global positioning systems gps
-95285	11-3071.02	24101505	pallet jacks		757d9dd3badb5030a15735aa524a561f	pallet jacks
-95293	11-3071.02	43231508	aljex inventory		a51542ed05a80adcd6e1297ad2e6a8c9	aljex inventory
-95294	11-3071.02	43231506	cadre technologies cadence warehouse management system		b7381ee6660af67f16e815eff0c50e1c	cadre technologies cadence warehouse management system
-95295	11-3071.02	43231506	catalyst international catalystconnect		b2b6b296aaf1cf02db85c76a1277bb17	catalyst international catalystconnect
-95296	11-3071.02	43231508	dsa foxware warehouse management		f8839463c3ab7290d320bfbfe275384b	dsa foxware warehouse management
-95298	11-3071.02	43231506	highjump software warehouse advantage		cb5bf07503e41a2221d604703dd235a3	highjump software warehouse advantage
-95303	11-3071.02	43231508	infosite technologies dm warehousing		319836b7b44db75badf366ea71a30a54	infosite technologies dm warehousing
-95308	11-3071.02	43231506	intellitrack warehouse management system		f2c2a13b6711e0ada0b51856c3b289c5	intellitrack warehouse management system
-95310	11-3071.02	43231508	logility voyager warehousepro		451e95d765cd0a118549e4df3aab07e0	logility voyager warehousepro
-95311	11-3071.02	43231506	materials requirements planning logistics and supply chain software		3f40afcc7f0152f80394078f76c4cd74	materials requirements planning logistics and supply chain software
-95320	11-3071.02	43231508	mra technologies mratrack warehouse management system		58c21f0240a9ffbbd43ce22b3ce1d66b	mra technologies mratrack warehouse management system
-95323	11-3071.02	43231506	radio beacon wms		149e08339fc5ae00ed724b8bf5f93c7d	radio beacon wms
-95324	11-3071.02	43231506	redprairie dlx warehouse		0cea60fce0a0568c5c7bdaa4b9fa021e	redprairie dlx warehouse
-95327	11-3071.02	43231508	sentai pinpoint		2b9e2e0004ecbe788c425935ab75812e	sentai pinpoint
-95329	11-3071.02	43231506	ssa global warehouse management system wms		1bd89b5fef7cd246375a76163c0751b1	ssa global warehouse management system wms
-95331	11-3071.02	43231506	tecsys eliteseries		a017e62211cc4db62ced3211ed0093ec	tecsys eliteseries
-95332	11-3071.02	43231506	tecsys pointforce enterprise		a6c4a4f8fded0ec5c4c969bc49ede893	tecsys pointforce enterprise
-95338	11-3071.03	46181509	personal protective equipment		414d1ab8da6aa0cab788b48a49cb0a38	personal protective equipment
-95340	11-3071.03	43231506	3pl central		3b53e43647bb8b7e20333ed1c2d72812	3pl central
-95341	11-3071.03	43231506	cadre technologies accuplus integrated distribution logistics system		c10daac57217a713160918b8b2417c8c	cadre technologies accuplus integrated distribution logistics system
-95345	11-3071.03	43231506	esri arclogistics		9fae8d451d799ab9e5f931de59f1f071	esri arclogistics
-95346	11-3071.03	43231506	fedex ship manager		a0c0573a2ce5e334bf012e7b5dda7c30	fedex ship manager
-95347	11-3071.03	43231506	four soft 4s elog		4d95d6efbee26049c05a2e5f56367cc3	four soft 4s elog
-95348	11-3071.03	43231506	four soft 4s visilog		a638e406150082266fdbb0f0e1657bbd	four soft 4s visilog
-95350	11-3071.03	43231506	intellitrack 3pl		d8a3201e489f3a29923666263ec501da	intellitrack 3pl
-95352	11-3071.03	43231506	logisuite enterprise		5eddd88740eeba99d536b4e0ccfff9d6	logisuite enterprise
-95353	11-3071.03	43231506	logisuite forwarder		b43722c7242519cd13f16dde051295a3	logisuite forwarder
-95354	11-3071.03	43231506	materials resource planning mrp software		046485a1e97da15f5ff6961ee6f072f3	materials resource planning mrp software
-95365	11-3071.03	43232605	optimization software		ae5b153685e48f83e841cb657980b535	optimization software
-95366	11-3071.03	43231506	oracle e-business suite logistics		14d90ef22e651866e868ea37d4b3bb3a	oracle ebusiness suite logistics
-95368	11-3071.03	43232106	presentation software		0346c9784b37cba998925003bac92bce	presentation software
-95369	11-3071.03	43232305	sap businessobjects software		e76ff7d80b9626141b07d3cc5b4d7b51	sap businessobjects software
-95370	11-3071.03	43231602	sap erp operations		efde3a97bda3ac976fc2725e49c3fad7	sap erp operations
-95373	11-3071.03	43233511	transportation management system tms software		764a79c8d6122de1b74f4dbecc4f8b08	transportation management system tms software
-95374	11-3071.03	43231602	transtek compass erp		7770398625554f229805e0d807fad6fb	transtek compass erp
-95375	11-3071.03	43231506	ups worldship		b65157b833d6b3f44998bbcb5e0a19f7	ups worldship
-95376	11-3071.03	43231506	usps.com		85ed91543a423799637800703498fc75	uspscom
+	O*NET-SOC Code	Element ID	ONET KSA	ksa_type	Description	skill_uuid	nlp_a
+255	11-3021.00	2.b.3.c	equipment selection	skill	determining the kind of tools and equipment needed to do a job.	035d26f14c0274510816c4f07c8ce8f3	equipment selection
+259	11-3021.00	2.b.3.j	equipment maintenance	skill	performing routine maintenance on equipment and determining when and what kind of maintenance is needed.	4b6e11c46579a9cebec51d9038c58d10	equipment maintenance
+261	11-3021.00	2.b.3.l	repairing	skill	repairing machines or systems using the needed tools.	b452c459a4485c0e7fe1d71d79801f51	repairing
+94655	11-3021.00	43222625	access servers	tool		2f36f12f543300d1b28997086c077112	access servers
+94656	11-3021.00	43211501	computer servers	tool		a51637a0ff334ff6a4240dd341cec440	computer servers
+94657	11-3021.00	27113203	computer tool kits	tool		23d38b13cc68e84e6f48861f23f3010d	computer tool kits
+94658	11-3021.00	43211501	file servers	tool		3e3e2221a18f3dbd0ea57cf73dd516bc	file servers
+94659	11-3021.00	43201407	industry standard architecture/peripheral component interconnect isa/pci cards	tool		081cf1f3cd5775b173df07b64e2f4922	industry standard architectureperipheral component interconnect isapci cards
+94660	11-3021.00	43212104	inkjet printers	tool		bdbd5ae91409d60393ead1ea3e32c09e	inkjet printers
+94661	11-3021.00	43211501	internet information services iis servers	tool		7e57e8b7544beac3aab463bd6643c7a3	internet information services iis servers
+94663	11-3021.00	43212105	laser printers	tool		0783a67db63c96881d6fc06fee31f1e7	laser printers
+94664	11-3021.00	43211512	mainframe computers	tool		ffef622c9a83001fb3ab45b55b743d3b	mainframe computers
+94665	11-3021.00	43211501	mid-range computers	tool		eace00184ed6391bc93c0ac6c1e6ddc9	midrange computers
+94666	11-3021.00	43211501	minicomputers	tool		474e29be277ca713600ac20f3679acce	minicomputers
+94667	11-3021.00	43211501	netware servers	tool		6cbe4dfe6ffb728a26bf4c0a17808d6f	netware servers
+94668	11-3021.00	41113711	network analyzers	tool		ae870e1ce33c8eb7aa804247201c35cc	network analyzers
+94669	11-3021.00	43201404	network interface cards nic	tool		e29746535ea658f1130327b015ad732d	network interface cards nic
+94670	11-3021.00	43222609	network routers	tool		ed85d0ff8d138169449f9bcfc51093d3	network routers
+94671	11-3021.00	43222612	network switches	tool		9abd8938573eb706ed5b3af6f53e34fc	network switches
+94674	11-3021.00	43201537	print servers	tool		2aab2c533b832ddc4e3bfd8d59361664	print servers
+94675	11-3021.00	27111505	punchdown tools	tool		26d492ced12d681e26b26767d9be583a	punchdown tools
+94676	11-3021.00	43222627	robot automation tool	tool		a83b2a2304f4c252e569d78c5379a4ac	robot automation tool
+94677	11-3021.00	27111701	screwdrivers	tool		ce9e15625cabeb7bb31d702645b95ccb	screwdrivers
+94678	11-3021.00	43211501	storage servers	tool		f55d7336a654ea3a3be9ad682fe014b3	storage servers
+94679	11-3021.00	43221522	teleconferencing equipment	tool		ecff0767db74528e41734e0e01d0c06d	teleconferencing equipment
+94680	11-3021.00	43211501	web servers	tool		f196462d0be07f3bcd139e427c6e691a	web servers
+94681	11-3021.00	43211502	workstations	tool		b13379aba36cbcabfa27ff4841d28ca8	workstations
+94682	11-3021.00	43232303	act! software	tool		355fea8c8105fa0e5cd7923dc5e61ef1	act software
+94684	11-3021.00	43232408	adobe systems adobe flex	tool		19ff1371d91d5ed03aa2869b17325ce5	adobe systems adobe flex
+94685	11-3021.00	43232405	advanced business application programming abap	tool		82a8948ebc48a0df829913235a385d59	advanced business application programming abap
+94686	11-3021.00	43232304	alphafour software	tool		be5a8b5b62fbd218054e0a74777042ac	alphafour software
+94689	11-3021.00	43232304	apache pig	tool		4c2819d1c90da1e5c6f8dfa7291d69e0	apache pig
+94690	11-3021.00	43232304	apache solr	tool		51c185588a8b97e1813bc23ea51bd358	apache solr
+94691	11-3021.00	43232408	apache tomcat	tool		b0bac281e1a992db7579705b348c5b20	apache tomcat
+94695	11-3021.00	43232110	apple iwork numbers	tool		62f216af26f81befeb2742970eab1378	apple iwork numbers
+94696	11-3021.00	43232104	apple iwork pages	tool		4626ac2c4fbd80908ddd55bc33715118	apple iwork pages
+94697	11-3021.00	43233004	apple macintosh os/x	tool		fb0eefedbd8fe0d1b8839b9a321efacc	apple macintosh osx
+94698	11-3021.00	43232402	assembler	tool		83fd5a089b5ebb6e9f93159c236dc320	assembler
+94699	11-3021.00	43231601	billing software	tool		c668f63290031cc33f4054e5af00ade3	billing software
+94700	11-3021.00	43232306	blackboard software	tool		f78b264fcc8f58958a8d44779a58001b	blackboard software
+94701	11-3021.00	43232405	borland paradox	tool		76f1764fa30025e55baf596d2e9501f5	borland paradox
+94702	11-3021.00	43232402	c	tool		4a8a08f09d37b73795649038408b5f33	c
+94703	11-3021.00	43232405	c++	tool		6ce809eacf90ba125b40fa4bd903962e	c
+94704	11-3021.00	43232310	ca erwin data modeler	tool		abbf2ec4498e2ca188757d6b7fbf4e4d	ca erwin data modeler
+94705	11-3021.00	43232909	cisco systems wan manager	tool		367073e7d3f2e455407c741d70c3871e	cisco systems wan manager
+94707	11-3021.00	43232402	common business oriented language cobol	tool		f3910fec4907c6459370ce69849d8abe	common business oriented language cobol
+94708	11-3021.00	43231513	corel office suite	tool		f3915bc0887eefec4cb8f5e47dbc54a0	corel office suite
+94709	11-3021.00	43232313	customer information control system ccis	tool		14556697d08d7457f4e0ea69bda4891e	customer information control system ccis
+94710	11-3021.00	43232801	dartware intermapper	tool		ce816cc393ec711f9eae8830a8958edb	dartware intermapper
+94712	11-3021.00	43232408	dynamic hypertext markup language dhtml	tool		0db059c4dd6ed3bbbaac64ee33279a47	dynamic hypertext markup language dhtml
+94714	11-3021.00	43232405	embarcadero delphi	tool		b2467b81bbc94a7043e971740d61239a	embarcadero delphi
+94717	11-3021.00	43233204	firewall software	tool		2c9e7547b6c759ea88978ae95ed7412d	firewall software
+94718	11-3021.00	43233001	ftp program software	tool		6cf7b619a576ee85b145f0aaee24136a	ftp program software
+94720	11-3021.00	43231501	help desk software	tool		5d0636cd96818b10d08d4162df24d5bc	help desk software
+94721	11-3021.00	43233004	hewlett packard hp-ux	tool		491fdb8cbd2229f8ccd0750cefe5afc2	hewlett packard hpux
+94722	11-3021.00	43231505	human resource management software hrms	tool		4527da9088257959d4a91722a48208b7	human resource management software hrms
+94723	11-3021.00	43232305	hyperion software	tool		ab836ca261d968887d9e3734c76d53ae	hyperion software
+94726	11-3021.00	43232403	ibm infosphere datastage	tool		06eeea0a85b24bf2084dea00c26e7891	ibm infosphere datastage
+94727	11-3021.00	43232915	ibm iseries access	tool		d6a79003da68d6d1f69618381974dafe	ibm iseries access
+94729	11-3021.00	43232403	ibm websphere	tool		6700aed160e6d0afb854bbe10071d834	ibm websphere
+94730	11-3021.00	43231602	infor erp baan	tool		bdb8c0841d8feb79de88752dac3b90ea	infor erp baan
+94731	11-3021.00	43232312	iplanet web server software	tool		28d52c4e30cf58d8722c968fd224b298	iplanet web server software
+94733	11-3021.00	43232402	k2 business process automation	tool		912b1de107447746d826b23e538c4b9f	k2 business process automation
+94734	11-3021.00	43232905	lan software	tool		2f99095dd34ebd4e6ae3b0b6b760673a	lan software
+94735	11-3021.00	43232306	langlais computer consultants calman	tool		e5f9fffcf633cafc23847d525619c536	langlais computer consultants calman
+94736	11-3021.00	43233004	linux	tool		e206a54e97690cce50cc872dd70ee896	linux
+94737	11-3021.00	43233501	linux-based email software	tool		265e83633224bc5adabb9f2ab2da0abe	linuxbased email software
+94738	11-3021.00	43232901	mac helpmate	tool		e5a71314f85b0a41d996ae9b68cd5907	mac helpmate
+94740	11-3021.00	43232402	microsoft .net framework	tool		674301048ce0213f63863f2e3560fada	microsoft net framework
+94742	11-3021.00	43232408	microsoft active server pages asp	tool		06fe645487690ce5db130dd6e4c08f07	microsoft active server pages asp
+94743	11-3021.00	43232303	microsoft business contact manager	tool		6268c3a27a6f0255870e39310b49b828	microsoft business contact manager
+94745	11-3021.00	43232303	microsoft dynamics crm	tool		a206bf3c78efe37bd31b5616e47dd153	microsoft dynamics crm
+94747	11-3021.00	43231602	microsoft dynamics nav	tool		2ab4ba1cf5102653a0ed7f35ddfdd2b6	microsoft dynamics nav
+94748	11-3021.00	43232108	microsoft entourage	tool		1383e4f69097f6fc405c8c385a428108	microsoft entourage
+94751	11-3021.00	43232107	microsoft front page	tool		4389da80da3e9d7271ae3ef8cdd63fa6	microsoft front page
+94753	11-3021.00	43233503	microsoft office sharepoint server moss	tool		1668117117bc5a95e8a47356af926648	microsoft office sharepoint server moss
+94759	11-3021.00	43232405	microsoft sql server reporting services ssrs	tool		be21b9d0235988a87cd29a039ef2ce31	microsoft sql server reporting services ssrs
+94763	11-3021.00	43232402	microsoft visual basic scripting edition vbscript	tool		99f365ebf0e9e7e8aa659d92bb029607	microsoft visual basic scripting edition vbscript
+94764	11-3021.00	43232311	microsoft visual foxpro	tool		16a26fd8d978e4b77b190083a8c25b02	microsoft visual foxpro
+94765	11-3021.00	43232402	microsoft visual studio	tool		8356f95d4bb62279fd99308dd36ed816	microsoft visual studio
+94766	11-3021.00	43232701	microsoft windows server	tool		0374fbf910ff24f949526c1d1693dd46	microsoft windows server
+94769	11-3021.00	43232910	mobile wireless network infrastructure software	tool		8048b6b72800432c9eb6d947721d8934	mobile wireless network infrastructure software
+94770	11-3021.00	43232304	mongodb	tool		685a5f7cc75b4796f6c6e00ccd384f01	mongodb
+94773	11-3021.00	43232705	netscape navigator	tool		98620c717bb2c63cdc142808860a0265	netscape navigator
+94774	11-3021.00	43232408	node.js	tool		28a3689be95c88dd5e7a37db516ab084	nodejs
+94775	11-3021.00	43232304	nosql software	tool		1962f3eb13f04aab14b76d00e09a16e8	nosql software
+94776	11-3021.00	43233002	novell network software	tool		e566b9897fbc0e00faaaf8970210369f	novell network software
+94777	11-3021.00	43232405	objective c	tool		3add2283d882284db4bca00242f32c0d	objective c
+94778	11-3021.00	43232314	oracle business intelligence enterprise edition	tool		c9c14d4b8fd1587b65dd79badbc7cece	oracle business intelligence enterprise edition
+94779	11-3021.00	43232306	oracle dbms	tool		10adae916fdaa6d2ba5980bb81a94f7b	oracle dbms
+94783	11-3021.00	43232405	oracle java	tool		27f2b03acd8b8784acab5c5b60118070	oracle java
+94786	11-3021.00	43232304	oracle pl/sql	tool		52f667e44a0668bca8f2a7075462897b	oracle plsql
+94787	11-3021.00	43231507	oracle primavera systems software	tool		002958fd200aae9a5eaba67a796841ff	oracle primavera systems software
+94789	11-3021.00	43233004	oracle solaris	tool		551185c96c3978a189d34ff0414ad3cf	oracle solaris
+94790	11-3021.00	43232701	oracle weblogic server	tool		d9fe9e61e1989fa02d381ac9c30e9358	oracle weblogic server
+94791	11-3021.00	43233501	pegasus software	tool		fc015ec322e8a477eedddddaa1f667ca	pegasus software
+94792	11-3021.00	43232303	performance solutions technology managepro	tool		0f0adc0d04e05ec1d78f5d0c51097730	performance solutions technology managepro
+94794	11-3021.00	43232606	pilgrim software pilgrim smartsolve software	tool		3e8e36ae4691e1829b1519f681762cb4	pilgrim software pilgrim smartsolve software
+94795	11-3021.00	43232312	plumtree software	tool		06347d6dd49e1251689d8137a7aa5b0e	plumtree software
+94796	11-3021.00	43232311	postgresql software	tool		6265067f488d81393ccd0776d8b205e8	postgresql software
+94797	11-3021.00	43232405	practical extraction and reporting language perl	tool		0c366e96abe4377fb976e4121f84476e	practical extraction and reporting language perl
+94798	11-3021.00	43232402	progress openedge abl	tool		d5d47ab628562b08f6f923aa2d459c9c	progress openedge abl
+94799	11-3021.00	43232701	progress openedge application server	tool		c7479581e03e4a96359290b6f78b6afe	progress openedge application server
+94800	11-3021.00	43232304	progress openedge fathom replication software	tool		0096bb83df55ea0ef961aefa3a995f25	progress openedge fathom replication software
+94801	11-3021.00	43232403	progress sonic esb	tool		047d7dbdb9981ea952aecf08a3e49c17	progress sonic esb
+94802	11-3021.00	43232408	progress webspeed workshop	tool		634730c99c08bfdc3b68ca9e83c59b89	progress webspeed workshop
+94803	11-3021.00	43232401	puppet	tool		768747907b90c39ab6f16fcb3320897a	puppet
+94804	11-3021.00	43232405	python	tool		23eeeb4347bdd26bfc6b7ee9a3b755dd	python
+94806	11-3021.00	43233501	qualcomm eudora	tool		0af00188129732f851b01928b62fdcb5	qualcomm eudora
+94808	11-3021.00	43233004	red hat enterprise linux	tool		b7958f6fcf3039fa7f9e8f375cb06bca	red hat enterprise linux
+94809	11-3021.00	43232701	red hat wildfly	tool		ea90ad928d5acee910f9042bb98ed56d	red hat wildfly
+94810	11-3021.00	43232304	relational database management software	tool		779c8394b38a9fe199596e21c9ef3c84	relational database management software
+94811	11-3021.00	43232408	ruby on rails	tool		ec49dc5392817d11fb8e9f880985e981	ruby on rails
+94812	11-3021.00	43233001	samba	tool		65575d0766c89ce103967995f76c41d2	samba
+94816	11-3021.00	43232804	solarwinds software	tool		d6df4906c9289ab722d30432cafc29d5	solarwinds software
+94817	11-3021.00	43232606	sox cobit	tool		0ee154fabce47245699d90d68e7e89ca	sox cobit
+94824	11-3021.00	43233001	symantec veritas file system	tool		6272d40bc060e6caf73a94a1b25bba9c	symantec veritas file system
+94825	11-3021.00	43233001	symantec veritas volume manager	tool		92ef6faf7b73d2cbd10c59d58020b5ce	symantec veritas volume manager
+94827	11-3021.00	43232911	telnet programs software	tool		d6f1e0701defd0b1ebd533b51e006e05	telnet programs software
+94829	11-3021.00	43232605	the mathworks matlab	tool		68bdaa4f3e4c787fc731e50fa0690837	the mathworks matlab
+94830	11-3021.00	43232404	tk software	tool		2f3e04e822b24eba16d7780d3d377d89	tk software
+94831	11-3021.00	43232407	unified modeling language uml	tool		3a09f6720c5935f75bd10aa819d4b767	unified modeling language uml
+94832	11-3021.00	43233004	unix	tool		4913a9178621eadcdf191db17915fbcb	unix
+94833	11-3021.00	43233415	veritas netbackup	tool		dcb585b233b8ff6042ce65acd759679f	veritas netbackup
+94834	11-3021.00	43233204	virtual private networking vpn software	tool		8cd20f6799b263a29e42c77d9c357f94	virtual private networking vpn software
+94835	11-3021.00	43232911	zephyr extra! terminal emulation	tool		1381136ff9737baecfde419afab7d5ad	zephyr extra terminal emulation
+94842	11-3031.01	43231602	aderant expert back office, powered by keystone	tool		61865b285c412887ecc272d520d81c06	aderant expert back office powered by keystone
+94843	11-3031.01	43231601	automatic data processing easypay software	tool		46956a66a2dca6018f34e63f46534185	automatic data processing easypay software
+94844	11-3031.01	43231505	automatic data processing pc payroll for windows pcpw	tool		a92d3401f0e8fcba9396790c438eeb56	automatic data processing pc payroll for windows pcpw
+94845	11-3031.01	43232110	corel quattropro	tool		36e9ae1c9d3dd348cf8353d824c53ba9	corel quattropro
+94846	11-3031.01	43231602	deltek software	tool		6c1af0e9471c4d8bc18774a0d10bcf7b	deltek software
+94847	11-3031.01	43231602	exact software macola es	tool		da53dcdd787ea7f9babe71dbe2461aa8	exact software macola es
+94848	11-3031.01	43231604	frx software	tool		e03b53012075afc6e2ac574f67757d84	frx software
+94850	11-3031.01	43231601	hyperion enterprise	tool		abb5e9f8131fd3218afc0ea77a83cf28	hyperion enterprise
+94851	11-3031.01	43231604	hyperion pillar software	tool		8c4530997c0a39c1a0b5c6363af3b089	hyperion pillar software
+94852	11-3031.01	43231602	hyperion solutions system 9 planning	tool		372f14c0da0b2102ea41afe5fcd11fac	hyperion solutions system 9 planning
+94855	11-3031.01	43232110	ibm lotus 1-2-3	tool		c388f4e7a6a3aa22e0f068b0100c0c08	ibm lotus 123
+94856	11-3031.01	43231602	infor erp syteline	tool		2b6ea855cfc2b6b5913b1c5252776ccb	infor erp syteline
+94858	11-3031.01	43231601	job costing software	tool		051e6a8f91ad4dd5f19f46e38f8c280d	job costing software
+94867	11-3031.01	43231601	myob premier accounting small business suite	tool		2c687d02fb18cd1aa7d6e402ed3e11f4	myob premier accounting small business suite
+94871	11-3031.01	43231602	oracle peoplesoft	tool		60779fe326229564ed5c87f240eb7be6	oracle peoplesoft
+94872	11-3031.01	43231602	oracle peoplesoft financials	tool		fab8ec2b7fd886d572b3818839354e84	oracle peoplesoft financials
+94875	11-3031.01	43231601	sage fixed asset solution fas	tool		c845f700a68b89c1c4be950850d69acc	sage fixed asset solution fas
+94876	11-3031.01	43231601	sage mip fund accounting	tool		4a5a7318d290bb6e5ad876bde64d0d15	sage mip fund accounting
+94879	11-3031.01	43231602	solomon software	tool		d3352972e16adcc44dd28cb6a50b1ad8	solomon software
+94888	11-3031.02	43231601	accounts receivable software	tool		5a3a426d3afcf0262387a5890ea0326a	accounts receivable software
+94889	11-3031.02	43231604	ares corporation prism project estimator	tool		00cd9c36bf69b0835942d5769dfcec26	ares corporation prism project estimator
+94890	11-3031.02	43231604	credit management software	tool		c29f209ae6cf5146f91bb18b79b7d195	credit management software
+94896	11-3031.02	43232705	internet browser software	tool		5d2a0bfc9e4001497f692841e2182c84	internet browser software
+94908	11-3031.02	43232110	moody's kmv famas	tool		3e48ef7dd755bf8e280cd919fdd159b9	moodys kmv famas
+94924	11-3031.02	43232104	word processing software	tool		dc46d4596698ec0cc7dfda998a74e3bf	word processing software
+94926	11-3051.00	24101603	forklifts	tool		d9d11d4f119ab7e7d29f26bff90390df	forklifts
+94931	11-3051.00	27111803	squares	tool		192ba166b3957ab1020e9a72ea1b40ed	squares
+94933	11-3051.00	27111801	tape measures	tool		10ec7e921659ddd3600cb26749054510	tape measures
+94934	11-3051.00	41111648	taper gauges	tool		e5a733614bd644a441b7edfb1017b9e9	taper gauges
+94935	11-3051.00	41111621	vernier calipers	tool		641ae6a08800e6ae1b32d033a0c7815a	vernier calipers
+94936	11-3051.00	43232603	abb optimize software	tool		c8dd1827b58f78a3e8a0418d97fbcf4c	abb optimize software
+94942	11-3051.00	43232604	autodesk autocad	tool		9c4d7d28b2f883d41c580778012a2f13	autodesk autocad
+94943	11-3051.00	43232608	citect iim	tool		264f5d3e39f07087a4f73e27b626a1f1	citect iim
+94944	11-3051.00	43232608	citectscada reports	tool		70ca77a375a2925d7c75737dea87eae5	citectscada reports
+94945	11-3051.00	43232608	citectscada software	tool		c1eafec5f20ae14d3a615e96f9c3478a	citectscada software
+94946	11-3051.00	43231505	clockware software	tool		491c06cf01b2fb8bef610cbb486698af	clockware software
+94947	11-3051.00	43232604	computer aided design cad software	tool		1508af139d359641efcfdbfb616bbfcb	computer aided design cad software
+94948	11-3051.00	43232108	computer integrated manufacturing cim software	tool		1f1bfbebd9adbb13bb413d0a31835204	computer integrated manufacturing cim software
+94949	11-3051.00	43231505	computer integrated manufacturing cim time manager software	tool		b7b8f860f5a522276fdc49d00334fcdb	computer integrated manufacturing cim time manager software
+94950	11-3051.00	43231508	computer integrated manufacturing cim warehouse shipping manager software	tool		46d9aa6f4101df3dff488fb8af0690f1	computer integrated manufacturing cim warehouse shipping manager software
+94951	11-3051.00	43232104	corvu software	tool		8e335771d97b54916e6c6cbac83d3ba6	corvu software
+94953	11-3051.00	43231505	employee performance management software	tool		67205951a4e21482397c91eb3d7d16c9	employee performance management software
+94954	11-3051.00	43232306	exact software jobboss	tool		b0d6626e3e01b909588420b047f53e4a	exact software jobboss
+94956	11-3051.00	43231604	financial planning software	tool		e8011ee860fcf0326ff469250f0b3086	financial planning software
+94957	11-3051.00	43232402	ibm rational clearquest	tool		f0ef5799896729f514d05d38f642a90f	ibm rational clearquest
+94958	11-3051.00	43232608	industrial production manager and stock control software	tool		f8bbf7e62cfdcd8482d2279d7dd3aa87	industrial production manager and stock control software
+94959	11-3051.00	43231601	intuit quickbooks manufacturing & wholesale software	tool		9a9477076396783adb1e084e4190ccdc	intuit quickbooks manufacturing  wholesale software
+94960	11-3051.00	43232608	marel production system mps software	tool		8ee03b234047b90cf0a7136b967daa61	marel production system mps software
+94970	11-3051.00	43232603	plant management software	tool		921d80412cfe3d6ead46d908a59e877e	plant management software
+94971	11-3051.00	43231602	processpro premier	tool		14b3470e2cfe6085f378c2d29a664454	processpro premier
+94972	11-3051.00	43232608	prosys software	tool		a780ac63da1ca6603274cdf656f2a411	prosys software
+94973	11-3051.00	43232202	qumas software	tool		02b511f7123ebcfa4901ffe0cbcd896f	qumas software
+94974	11-3051.00	43231508	sap inventory software	tool		9c8188d270b1d0a696bdf26e4f01b169	sap inventory software
+94976	11-3051.00	43232306	scadex technologies maestro	tool		6651f028b4f7b61275251ea5613518bc	scadex technologies maestro
+94977	11-3051.00	43232608	statistical process control software	tool		d7d8839b7f7adfdcbc80beacd82e8500	statistical process control software
+94978	11-3051.00	43232608	wonderware dt analyst plant productivity improvement software	tool		040653e3cc354c357e7858dea0a7432f	wonderware dt analyst plant productivity improvement software
+94979	11-3051.00	43232108	workschedule software	tool		2b3f17d1ca6ea2813a031ddd65c8f5bd	workschedule software
+94980	11-3051.01	41121502	automated diluters	tool		1ba9360609bc1592ed19bee4371c5af3	automated diluters
+94981	11-3051.01	41113037	automated microplate elisa readers	tool		4acbd0210ff327e580066a40c9a0cf72	automated microplate elisa readers
+94982	11-3051.01	41115819	cellular assay equipment	tool		1f8d627372fbc8c3aa3ea0c68f8ef007	cellular assay equipment
+94983	11-3051.01	43212104	computer inkjet printers	tool		dbd58b58eacd3fcd35ed74ee02231951	computer inkjet printers
+94984	11-3051.01	41105307	electrophoresis equipment	tool		14aa62071fafc1e3bd91a4f219c4bdd9	electrophoresis equipment
+94985	11-3051.01	41115408	fourier transfer infrared ftir spectrometers	tool		cb77fd78c3f21c3ac52de8a30055cdad	fourier transfer infrared ftir spectrometers
+94986	11-3051.01	41115703	gas chromatography equipment	tool		0e1820db1126c3138a53aa9281d89583	gas chromatography equipment
+94987	11-3051.01	43211715	handheld data collectors	tool		a4d0bd9af457aeac96151ccb77fba77a	handheld data collectors
+94988	11-3051.01	41115403	infrared spectroscopic equipment	tool		ba2de37bb31db6d6b795596018be1736	infrared spectroscopic equipment
+94989	11-3051.01	41111517	laboratory analytical balances	tool		f258e5beb7f11c18bfb92bc66a1bc199	laboratory analytical balances
+94990	11-3051.01	41103903	laboratory benchtop centrifuges	tool		cd5b525b5c8c12edc8150d432b91aeea	laboratory benchtop centrifuges
+94991	11-3051.01	41104806	laboratory extraction equipment	tool		9bb66ac25ef52c84818a173bda028f4a	laboratory extraction equipment
+94992	11-3051.01	41111513	laboratory moisture balances	tool		5d86198ea315b8071ecbdc7db86e12cd	laboratory moisture balances
+94994	11-3051.01	41115705	liquid chromatography equipment	tool		8ff296900c8f0a06121394303a28727a	liquid chromatography equipment
+94996	11-3051.01	41115603	ph analyzers	tool		c9481f0fcfb4d1fba2940e428d5dc2b9	ph analyzers
+94997	11-3051.01	41115602	titrators	tool		8f25f9ef67ca7d970663071a0432d468	titrators
+94999	11-3051.01	43232608	asi datamyte gagemetrics	tool		b4183ce3d10f92bf87628f25d3f81260	asi datamyte gagemetrics
+95000	11-3051.01	43232608	asi datamyte qda software	tool		94f968e030143c2ed65bc73700f6f313	asi datamyte qda software
+95001	11-3051.01	43232608	asidatamyte datametrics	tool		d9bff4fcc9166db62b4c1af40c4749db	asidatamyte datametrics
+95002	11-3051.01	43232608	cama software quality collaboration by design software	tool		958e001030a5f6fcdaaffd54e62b5d04	cama software quality collaboration by design software
+95003	11-3051.01	43232608	cebos mq1 software	tool		0ba66a98a8381c804fdee742481488ea	cebos mq1 software
+95004	11-3051.01	43232605	computing solutions labsoft lims	tool		7ac03f43ed30052a644c1fb783d079e1	computing solutions labsoft lims
+95005	11-3051.01	43232605	core informatics laboratory information management system lims software	tool		def17ba0c134d4823c7eac93a9a26690	core informatics laboratory information management system lims software
+95006	11-3051.01	43232606	etq reliance software	tool		5c85a7d492d63130a15b2f53afbebca0	etq reliance software
+95008	11-3051.01	43232306	harrington group caweb software	tool		189bc87a70fe4d6172aea34ca706cf0d	harrington group caweb software
+95009	11-3051.01	43232608	harrington group hqms software	tool		ecb5b02afbff042f1c5156110e6daac9	harrington group hqms software
+95010	11-3051.01	43232406	hewlett packard loadrunner	tool		20bcb70c57f0bb56f48ca1abc6c56368	hewlett packard loadrunner
+95011	11-3051.01	43232605	illumina laboratory information management system lims software	tool		56d8c4e5653addfcd942e35527ddabe7	illumina laboratory information management system lims software
+95012	11-3051.01	43232608	infinity qs proficient software	tool		fe5a181a44a590f3f4930b65e9096935	infinity qs proficient software
+95013	11-3051.01	43232605	lablite laboratory information management systems lims software	tool		b7cab97f6f3e19b51c296624188077f6	lablite laboratory information management systems lims software
+95014	11-3051.01	43232608	laboratory automated quality control systems laqc software	tool		fbe7fdec5bb45d97845f83b51d50af04	laboratory automated quality control systems laqc software
+95015	11-3051.01	43232605	labvantage solutions lims	tool		78c70edec88119dc9ea895b458212e55	labvantage solutions lims
+95017	11-3051.01	43232606	mastercontrol software	tool		01102bb9b423bdf4bf6b242e40b533d0	mastercontrol software
+95028	11-3051.01	43232605	pearson education phstat2	tool		535590a82fad68401c7c46d1c277f23a	pearson education phstat2
+95029	11-3051.01	43232608	pq systems chartrunner lean	tool		d8da5875239948298f5888a535168f59	pq systems chartrunner lean
+95030	11-3051.01	43232608	pq systems gagepack	tool		065c156756542bb61b4bf53a7d6038cd	pq systems gagepack
+95031	11-3051.01	43232608	pq systems measurespy	tool		addbc1e22d88612a36e42fb14bb8e898	pq systems measurespy
+95032	11-3051.01	43232605	pq systems sqcpack	tool		45596433b488fd6b61bface90c381d0d	pq systems sqcpack
+95033	11-3051.01	43232605	promium element datasystem lims	tool		e81e4e0161127f0a4c95ea314345b0c9	promium element datasystem lims
+95034	11-3051.01	43232605	quality systems international winlims	tool		633ca03cf7444a31b682f47030ad8a33	quality systems international winlims
+95036	11-3051.01	43232606	sparta systems trackwise	tool		7e31d578429bc1e9d35dec64fdde3b83	sparta systems trackwise
+95037	11-3051.01	43232605	starlims software	tool		2a8983aaadf10f1db007cc406870c6b6	starlims software
+95038	11-3051.01	43232605	statgraphics software	tool		7d4238179f2aebdb8251644885e8b2b9	statgraphics software
+95040	11-3051.01	43232605	systat software lisa.lims	tool		7086a0d2f3f3feac620eeddb388003b9	systat software lisalims
+95041	11-3051.01	43232605	thermo fisher scientific laboratory information management systems (lims) software	tool		80894a4e01dcd5d5d08015ccd00c302a	thermo fisher scientific laboratory information management systems lims software
+95042	11-3051.01	43232608	vivaldi software vivaldi quality management software	tool		7232aa38be05ff95b8fd4279dcb95766	vivaldi software vivaldi quality management software
+95044	11-3051.02	43211715	dataloggers	tool		b2b6e99ef01d9e10f5104a8788cef090	dataloggers
+95046	11-3051.02	26111601	diesel-powered generators	tool		b519756cc711ab83d6113f5f70fee2e1	dieselpowered generators
+95049	11-3051.02	40151510	large volume water pumps	tool		baa2ea9b470d69549a4c0a0f0e7bff9e	large volume water pumps
+95050	11-3051.02	24101623	material moving cranes	tool		c11d4ad5640047c558b7c5011fe6ba02	material moving cranes
+95051	11-3051.02	43191510	mobile radios	tool		4b8886f10d8705a9dc555099a6853697	mobile radios
+95054	11-3051.02	32101628	programmable logic controllers plc	tool		a8972632d229ff660f529dd9ff59d9f5	programmable logic controllers plc
+95056	11-3051.02	43232306	datalogging software	tool		b1bb6de5a9f4cc682b19b1efec306940	datalogging software
+95057	11-3051.02	43232306	infostat rimbase	tool		f5d5ea4d35bc7b3d999f8328e01ec152	infostat rimbase
+95064	11-3051.03	41104008	air monitoring equipment	tool		ba3efca8a47535be32a4c28f31338f3a	air monitoring equipment
+95065	11-3051.03	40141607	ball valves	tool		1944870a1d05bd0bc52feead0c005b3d	ball valves
+95066	11-3051.03	24101712	belt conveyor systems	tool		17c32004fd6fc782d656c1a3303092d0	belt conveyor systems
+95068	11-3051.03	46182002	dust and particulate respirators	tool		922387afa5ad915d55c332d0f82ec1b7	dust and particulate respirators
+95069	11-3051.03	46171603	electric timing devices	tool		c41dec036d663e22b39194c9dc20321e	electric timing devices
+95070	11-3051.03	46171604	emergency alarm systems	tool		7b5bcb5108495f16505848ef9d91bfc0	emergency alarm systems
+95071	11-3051.03	41104301	fermentation processing vessels	tool		74c678ef999fe9b217ba05c0abb23a18	fermentation processing vessels
+95072	11-3051.03	40141609	flow control valves fcv	tool		81cc59247660ae636c92845b6e1c5ced	flow control valves fcv
+95074	11-3051.03	40141613	gate butterfly valves	tool		eb0963428b20e28b5e0745ef73cbb7cb	gate butterfly valves
+95075	11-3051.03	41121805	glass graduated cylinders	tool		bb5bb674c00df49fc89844dd9ce27d5b	glass graduated cylinders
+95076	11-3051.03	41104501	gravity convection ovens	tool		1aacb52da07cc68bdac56e4a35ba6a3e	gravity convection ovens
+95077	11-3051.03	40151506	hand sampling pumps	tool		c46989784fd2bb1a20a6bff8352b2fa4	hand sampling pumps
+95078	11-3051.03	47131905	hazardous material spill kits	tool		7ea58344ec7cb87f63367773d778db9e	hazardous material spill kits
+95080	11-3051.03	41112304	moisture analyzers	tool		3f2b17e75a67f8c3311a58eba955edd5	moisture analyzers
+95081	11-3051.03	41105003	mole sieves	tool		ecb3afe1c3f44dbca7a3aabf33b969cc	mole sieves
+95083	11-3051.03	41115603	ph probes	tool		e5b1e1eee1aefca45bca16e117771bf1	ph probes
+95084	11-3051.03	41121804	reaction flasks	tool		9c54fd6360118f4b60a885aa14315dca	reaction flasks
+95085	11-3051.03	41104015	sample ports	tool		4b6169a0efe7904e6c3ab1485062bec1	sample ports
+95086	11-3051.03	46182004	self-contained breathing apparatus	tool		730d20401cd16318026c248cbe9cc3f1	selfcontained breathing apparatus
+95087	11-3051.03	40141611	stop valves	tool		ba87bbd29a4dd2ca4cc70cb2bb1ba8cb	stop valves
+95088	11-3051.03	40141609	throttle control valves tcv	tool		67e82d02a3bc0685553f3d42ea0a56b7	throttle control valves tcv
+95090	11-3051.03	43232603	computerized maintenance management system cmms software	tool		9db25b1044cb1133f99818b9497055b3	computerized maintenance management system cmms software
+95091	11-3051.03	43232608	distributed control systems dcs software	tool		bcd4ac0ca710985cc1d9d5315bc8287d	distributed control systems dcs software
+95092	11-3051.03	43232108	employee scheduling software	tool		0af814e7726201706e636143fb452394	employee scheduling software
+95093	11-3051.03	43232608	human machine interface hmi software	tool		3cb1bc5763299f9f2b1dccceb94b6267	human machine interface hmi software
+95094	11-3051.03	43231508	inventory control software	tool		1bb70d55351190ba55e21d36d31fddca	inventory control software
+95101	11-3051.04	40102001	biomass boilers	tool		eaa6c022055113655ce77cd75cd7f5d0	biomass boilers
+95102	11-3051.04	40102001	bubbling fluidized bed boilers	tool		9c6f151dbbbc59aae792896cc5c5a6ba	bubbling fluidized bed boilers
+95103	11-3051.04	40102001	circulating fluidized bed boilers	tool		ba458e9ed7f94a5c3eacd5623ddfe2b9	circulating fluidized bed boilers
+95104	11-3051.04	40101703	cooling towers	tool		890d1f8c7ef2e26f8712d315885965a0	cooling towers
+95106	11-3051.04	26111608	heat recovery steam generators	tool		9ee3a00d90a73f632a690572b3a8222a	heat recovery steam generators
+95109	11-3051.04	24101708	radial stackers	tool		ecb3e8923a1cebaeb4425c6c1a9d9131	radial stackers
+95110	11-3051.04	40102002	steam boilers	tool		cb78fe5c3ee5dec93fdbe9b3df04a92f	steam boilers
+95111	11-3051.04	26101505	steam turbines	tool		412264a0ee3b07e40d0dcf298c825160	steam turbines
+95112	11-3051.04	41104007	water samplers	tool		6adef2d5798942c43aac734cbe311745	water samplers
+95113	11-3051.04	22101715	wood feed systems	tool		f8e69a5ef0343444dd9e2beb8d28e92b	wood feed systems
+95124	11-3051.05	41104008	air samplers	tool		2526fc60bdd044b89a6e7d4c71f40208	air samplers
+95125	11-3051.05	25101905	all terrain vehicles atv	tool		175ac3812e312e9f1aa7d4cd34d21b24	all terrain vehicles atv
+95126	11-3051.05	26131701	combustible gas monitors	tool		c9531c6ad03d00bb24e752c0867b7318	combustible gas monitors
+95128	11-3051.05	26111601	diesel reciprocating engine generator sets	tool		22c800c817480044429ff94fc781c451	diesel reciprocating engine generator sets
+95129	11-3051.05	26131608	enclosed flares	tool		66fa961b669d916d43d92b046497b62b	enclosed flares
+95130	11-3051.05	46171613	gas leak detectors	tool		73f0d31efaa4e202347d4042f1a1019d	gas leak detectors
+95131	11-3051.05	26111604	gas reciprocating engine generator sets	tool		4d2bf755c1c35bf639d432b26e2ce931	gas reciprocating engine generator sets
+95132	11-3051.05	41114401	micro anemometers	tool		1826e4f13d57e25999b13dd93e4d37b4	micro anemometers
+95133	11-3051.05	41113118	multiple gas monitors	tool		e1837652cd805c242ee63f7e469c258d	multiple gas monitors
+95135	11-3051.05	26131608	open flares	tool		509fc5e6b1a99e76bb5c89815e6c1441	open flares
+95136	11-3051.05	41113110	oxygen analyzers	tool		422c6d205a51532a95d258099d08c46d	oxygen analyzers
+95138	11-3051.05	41111927	pressure gauges	tool		babb42bced21d09b0d28c39415ce856e	pressure gauges
+95139	11-3051.05	40141604	pressure valves	tool		01cf46d2c9fcd5819857856a2d9ee20d	pressure valves
+95140	11-3051.05	25101507	utility trucks	tool		78d4b92e043a8233bfa0344c90f745f3	utility trucks
+95145	11-3051.05	43232605	landfill gas analysis software	tool		5d3398bf8cb4538710b6b86c1ec1dab4	landfill gas analysis software
+95146	11-3051.05	43232605	landtec system software lfg pro	tool		4ceb5ad8de1c27a792ca66dfe3663191	landtec system software lfg pro
+95152	11-3051.05	43231602	worktech maximo	tool		9e3cbe5df49b852ef526f1adb256daf2	worktech maximo
+95153	11-3051.06	40142207	dam water flow controls	tool		40c241e059fbc3ae17aa0ffaf1164e3f	dam water flow controls
+95155	11-3051.06	39121601	electrical circuit breakers	tool		f8e58ede92be7c23080d2b8978ad08d9	electrical circuit breakers
+95156	11-3051.06	26131808	electrical switch gear	tool		ed8806414b15831811f9835693d5bd0e	electrical switch gear
+95157	11-3051.06	26111606	hydraulic power generation equipment	tool		4b3d9ffd878e7cf7ef698a2410abea54	hydraulic power generation equipment
+95158	11-3051.06	26131803	hydroelectric power generator controls	tool		df5b3d0216a85152a1b10308c39db09a	hydroelectric power generator controls
+95159	11-3051.06	26101506	impulse turbines	tool		783db8362956d3da2e4e0ce919779722	impulse turbines
+95163	11-3051.06	39121002	power transformers	tool		3116dcd7c3f7b7bb6ec5fb0d5e521bc6	power transformers
+95164	11-3051.06	46181902	protective ear muffs	tool		85c4a2141b644599e0107d96b24a451f	protective ear muffs
+95165	11-3051.06	46182002	protective respirators	tool		aa5cdc7c2bf10236fadb560b660bcc64	protective respirators
+95166	11-3051.06	26101506	reaction turbines	tool		654e8d0a36115ac3731f63c227880f29	reaction turbines
+95167	11-3051.06	46181802	safety glasses	tool		36647620d781132d4d337f3c162fbb93	safety glasses
+95168	11-3051.06	26101506	turbine generators	tool		cb6fad1cfa0641e9d63affbfdaf03957	turbine generators
+95178	11-3051.06	43232608	supervisory control and data acquisition scada software	tool		8308afefad6807aa299dda26f954db72	supervisory control and data acquisition scada software
+95182	11-3061.00	43231503	ariba spend management suite	tool		0421a28bf853727d8bc7e53d19d32dc2	ariba spend management suite
+95183	11-3061.00	43231503	automated purchase order software	tool		23979feae7812aa7e35634b949c3b70c	automated purchase order software
+95184	11-3061.00	43231503	bottomline technologies bottomline sprinter purchasing manager	tool		05d545cf4be8349e1f307a3bd99d0736	bottomline technologies bottomline sprinter purchasing manager
+95185	11-3061.00	43231602	bowen & groves m1 erp	tool		83a3c72ddcadef1b9971a84a3289d392	bowen  groves m1 erp
+95186	11-3061.00	43232306	corel paradox	tool		154e10dc9dd7506b921630a15533a7ae	corel paradox
+95189	11-3061.00	43231602	epicor vantage erp	tool		3e26e4b34368292b25722915ee660e3a	epicor vantage erp
+95191	11-3061.00	43231506	infor lawson supply chain management	tool		439c1565ba5b6b2132eb64f43b0520b0	infor lawson supply chain management
+95193	11-3061.00	43231506	material requirement planning mrp software	tool		7d3a633257c042128d2ec857b52e5d7a	material requirement planning mrp software
+95206	11-3061.00	43231604	oracle peoplesoft enterprise financial management solutions	tool		ad59642d99ee06e38d170585dec795ed	oracle peoplesoft enterprise financial management solutions
+95207	11-3061.00	43231507	oracle primavera p6 enterprise portfolio project management	tool		af8eccb773f72a0dac2cc029a2d3f4aa	oracle primavera p6 enterprise portfolio project management
+95209	11-3061.00	43231503	purchasing software	tool		66a4f43ab5ec77084fb91bbb0de71dda	purchasing software
+95210	11-3061.00	43231503	purchasingnet eprocurement	tool		afe02e7138ecc5fb94ef7e9a56f500c4	purchasingnet eprocurement
+95215	11-3071.01	43211701	barcode scanners	tool		6f38c3959f94c686deeea72200d735ba	barcode scanners
+95216	11-3071.01	55121608	barcoding labels	tool		39b9fd75a800535e2e59ac02aa7f57d9	barcoding labels
+95222	11-3071.01	43221721	radio frequency handheld terminals	tool		6205d4c4639a6cfe39d8530b50b293a9	radio frequency handheld terminals
+95223	11-3071.01	43211710	radio frequency identification rfid devices	tool		955b6c67c28dbfa235674cccd245a67c	radio frequency identification rfid devices
+95224	11-3071.01	43221721	radio frequency truck-mounted terminals	tool		c479890e04b9b1992120d3e9b16dbf25	radio frequency truckmounted terminals
+95225	11-3071.01	43223209	wireless communication and satellite positioning tools	tool		ca834c359e1ee4f15e9b6ce4bf802de1	wireless communication and satellite positioning tools
+95226	11-3071.01	43231510	abol manifest systems	tool		18a4c2a01e014b4dd61203f1fad31615	abol manifest systems
+95227	11-3071.01	43232306	airline global distribution system gds software	tool		b76e89fa0c914e38d27c4a6cf9156288	airline global distribution system gds software
+95228	11-3071.01	43232504	alk technologies fleetsuite	tool		8a82d33bc4cab3170ac158996902e6e1	alk technologies fleetsuite
+95229	11-3071.01	43232504	alk technologies pc*miler	tool		c8b2407ab405a34a6cc7042e1f23f80d	alk technologies pcmiler
+95230	11-3071.01	43231506	amber road software	tool		3e9e492eafd54413bdc20cbc12c71d33	amber road software
+95231	11-3071.01	43231601	argos software abecas insight freight management system fms (accounting feature)	tool		dfd9c5e2b99ec5db528f971d864fabf0	argos software abecas insight freight management system fms accounting feature
+95232	11-3071.01	43232108	argos software abecas insight freight management system fms (calendar and scheduling feature)	tool		1ee2ffb9d0cd755582687f35104469f6	argos software abecas insight freight management system fms calendar and scheduling feature
+95233	11-3071.01	43231601	automated expense reporting system software	tool		ecfd210c138d24ba86630b147c6ed5b1	automated expense reporting system software
+95234	11-3071.01	43232306	bentley transportation data manager	tool		72c1ac829488e78524689b26180fe9dd	bentley transportation data manager
+95235	11-3071.01	43231506	cadre technologies cadence transportation management system	tool		1df452e6e139d9a119327b0b86d7aa37	cadre technologies cadence transportation management system
+95236	11-3071.01	43232504	copilot truck	tool		7a0d515519124ff700209ae8be11872a	copilot truck
+95237	11-3071.01	43232605	eaton fleet advisor	tool		a8dc4a273d7081855b5407edb17a2bf6	eaton fleet advisor
+95239	11-3071.01	43231506	fleetware software	tool		fd2f10eb2d149de08b7d463bb006e675	fleetware software
+95240	11-3071.01	43232605	freight rail crew optimization scheduling frcos software	tool		6e7ff676d9ca898d457c9c342203fea1	freight rail crew optimization scheduling frcos software
+95241	11-3071.01	43231506	geometrix	tool		b56d71d52ac96df160d816b7a14a2f4f	geometrix
+95242	11-3071.01	43232102	graphics software	tool		5d1fa103ef1e9561b0c13afb1c7b9326	graphics software
+95243	11-3071.01	43231506	ibm i2 transportation manager	tool		6026ff992f2fc47bd13033533fe0ef46	ibm i2 transportation manager
+95245	11-3071.01	43232605	imsure solutions shipflex	tool		3a47994e5a10fac62c6f5cfb14299131	imsure solutions shipflex
+95246	11-3071.01	43231506	infosite technologies dispatch-mate	tool		8b8e90676c965d0f2bf1078df230d95c	infosite technologies dispatchmate
+95247	11-3071.01	43231506	integrated decision support corporation expert fuel	tool		50c0d991d8a22ef2072fcba845c68738	integrated decision support corporation expert fuel
+95248	11-3071.01	43231506	integrated decision support corporation netwise supply chain	tool		3a34a7d517050a25b074023467f5a487	integrated decision support corporation netwise supply chain
+95249	11-3071.01	43232504	integrated decision support corporation route advice	tool		67b593d6ddd6bc1c0208ae77155efa91	integrated decision support corporation route advice
+95250	11-3071.01	43231506	integrated decision support corporation swap advice	tool		cee08e08011f7ce2a17ee108c48bb6eb	integrated decision support corporation swap advice
+95251	11-3071.01	43232605	integrated decision support match advice	tool		21f9443d4cd3097abfe24908f5bbfddc	integrated decision support match advice
+95252	11-3071.01	43232605	integrated decision support netwise enterprise	tool		2a674a3962e5662debe6b13d13502b84	integrated decision support netwise enterprise
+95253	11-3071.01	43232605	integrated decision support netwise frontline	tool		e379c833c3a9c6b7181a20a48265226a	integrated decision support netwise frontline
+95254	11-3071.01	43232504	intergraph geomedia transportation manager	tool		32b281d69aad9ac2e891656faa9c80f5	intergraph geomedia transportation manager
+95255	11-3071.01	43231508	international business systems software	tool		d94420a4be7f5858e1811fdfbaeeeb1f	international business systems software
+95256	11-3071.01	43232306	labelmaster software reg-trieve	tool		65760813c2ba3a935ebfe9482757627a	labelmaster software regtrieve
+95265	11-3071.01	43232605	qualcomm qtracs	tool		efab0bce087c82486527a6ad4d702536	qualcomm qtracs
+95266	11-3071.01	43232605	qualcomm viaweb	tool		11ccfe8718f3d405023d3c3bb29baccb	qualcomm viaweb
+95268	11-3071.01	43232606	scanlon associates logpak	tool		770ff6e1f4cfee1b024fdb8725990b6b	scanlon associates logpak
+95269	11-3071.01	43232606	shipping solutions software	tool		577e1e0f2d39a6755549f83cad166b37	shipping solutions software
+95270	11-3071.01	43232110	spreadsheet software	tool		72dda444bdc23d4873055a8641c11428	spreadsheet software
+95272	11-3071.01	43231506	summary systems fleet commander	tool		9573f479ab288aea6c6262259048b7d9	summary systems fleet commander
+95273	11-3071.01	43231506	supply chain event management software	tool		5382d6b1742e918c08bdcf5f71b430ee	supply chain event management software
+95274	11-3071.01	43231602	tmw powersuite	tool		ae585291c0c0412cfa51cbdfd3a72e4d	tmw powersuite
+95276	11-3071.01	43231605	workforce software empcenter time and attendance	tool		f8313424d559fd061034b0a02a8ffcda	workforce software empcenter time and attendance
+95283	11-3071.02	25173107	global positioning systems gps	tool		bbcb58429df0de339eeda241196b7972	global positioning systems gps
+95285	11-3071.02	24101505	pallet jacks	tool		757d9dd3badb5030a15735aa524a561f	pallet jacks
+95293	11-3071.02	43231508	aljex inventory	tool		a51542ed05a80adcd6e1297ad2e6a8c9	aljex inventory
+95294	11-3071.02	43231506	cadre technologies cadence warehouse management system	tool		b7381ee6660af67f16e815eff0c50e1c	cadre technologies cadence warehouse management system
+95295	11-3071.02	43231506	catalyst international catalystconnect	tool		b2b6b296aaf1cf02db85c76a1277bb17	catalyst international catalystconnect
+95296	11-3071.02	43231508	dsa foxware warehouse management	tool		f8839463c3ab7290d320bfbfe275384b	dsa foxware warehouse management
+95298	11-3071.02	43231506	highjump software warehouse advantage	tool		cb5bf07503e41a2221d604703dd235a3	highjump software warehouse advantage
+95303	11-3071.02	43231508	infosite technologies dm warehousing	tool		319836b7b44db75badf366ea71a30a54	infosite technologies dm warehousing
+95308	11-3071.02	43231506	intellitrack warehouse management system	tool		f2c2a13b6711e0ada0b51856c3b289c5	intellitrack warehouse management system
+95310	11-3071.02	43231508	logility voyager warehousepro	tool		451e95d765cd0a118549e4df3aab07e0	logility voyager warehousepro
+95311	11-3071.02	43231506	materials requirements planning logistics and supply chain software	tool		3f40afcc7f0152f80394078f76c4cd74	materials requirements planning logistics and supply chain software
+95320	11-3071.02	43231508	mra technologies mratrack warehouse management system	tool		58c21f0240a9ffbbd43ce22b3ce1d66b	mra technologies mratrack warehouse management system
+95323	11-3071.02	43231506	radio beacon wms	tool		149e08339fc5ae00ed724b8bf5f93c7d	radio beacon wms
+95324	11-3071.02	43231506	redprairie dlx warehouse	tool		0cea60fce0a0568c5c7bdaa4b9fa021e	redprairie dlx warehouse
+95327	11-3071.02	43231508	sentai pinpoint	tool		2b9e2e0004ecbe788c425935ab75812e	sentai pinpoint
+95329	11-3071.02	43231506	ssa global warehouse management system wms	tool		1bd89b5fef7cd246375a76163c0751b1	ssa global warehouse management system wms
+95331	11-3071.02	43231506	tecsys eliteseries	tool		a017e62211cc4db62ced3211ed0093ec	tecsys eliteseries
+95332	11-3071.02	43231506	tecsys pointforce enterprise	tool		a6c4a4f8fded0ec5c4c969bc49ede893	tecsys pointforce enterprise
+95338	11-3071.03	46181509	personal protective equipment	tool		414d1ab8da6aa0cab788b48a49cb0a38	personal protective equipment
+95340	11-3071.03	43231506	3pl central	tool		3b53e43647bb8b7e20333ed1c2d72812	3pl central
+95341	11-3071.03	43231506	cadre technologies accuplus integrated distribution logistics system	tool		c10daac57217a713160918b8b2417c8c	cadre technologies accuplus integrated distribution logistics system
+95345	11-3071.03	43231506	esri arclogistics	tool		9fae8d451d799ab9e5f931de59f1f071	esri arclogistics
+95346	11-3071.03	43231506	fedex ship manager	tool		a0c0573a2ce5e334bf012e7b5dda7c30	fedex ship manager
+95347	11-3071.03	43231506	four soft 4s elog	tool		4d95d6efbee26049c05a2e5f56367cc3	four soft 4s elog
+95348	11-3071.03	43231506	four soft 4s visilog	tool		a638e406150082266fdbb0f0e1657bbd	four soft 4s visilog
+95350	11-3071.03	43231506	intellitrack 3pl	tool		d8a3201e489f3a29923666263ec501da	intellitrack 3pl
+95352	11-3071.03	43231506	logisuite enterprise	tool		5eddd88740eeba99d536b4e0ccfff9d6	logisuite enterprise
+95353	11-3071.03	43231506	logisuite forwarder	tool		b43722c7242519cd13f16dde051295a3	logisuite forwarder
+95354	11-3071.03	43231506	materials resource planning mrp software	tool		046485a1e97da15f5ff6961ee6f072f3	materials resource planning mrp software
+95365	11-3071.03	43232605	optimization software	tool		ae5b153685e48f83e841cb657980b535	optimization software
+95366	11-3071.03	43231506	oracle e-business suite logistics	tool		14d90ef22e651866e868ea37d4b3bb3a	oracle ebusiness suite logistics
+95368	11-3071.03	43232106	presentation software	tool		0346c9784b37cba998925003bac92bce	presentation software
+95369	11-3071.03	43232305	sap businessobjects software	tool		e76ff7d80b9626141b07d3cc5b4d7b51	sap businessobjects software
+95370	11-3071.03	43231602	sap erp operations	tool		efde3a97bda3ac976fc2725e49c3fad7	sap erp operations
+95373	11-3071.03	43233511	transportation management system tms software	tool		764a79c8d6122de1b74f4dbecc4f8b08	transportation management system tms software
+95374	11-3071.03	43231602	transtek compass erp	tool		7770398625554f229805e0d807fad6fb	transtek compass erp
+95375	11-3071.03	43231506	ups worldship	tool		b65157b833d6b3f44998bbcb5e0a19f7	ups worldship
+95376	11-3071.03	43231506	usps.com	tool		85ed91543a423799637800703498fc75	uspscom

--- a/tests/api_sync/v1/test_skills_importance.py
+++ b/tests/api_sync/v1/test_skills_importance.py
@@ -121,8 +121,8 @@ def test_skills_importance():
         # this task depends on jobs and skills master being loaded
         # so add the needed rows
         session.add(JobMaster('job_uuid', '11-1011.00', '', '', '', ''))
-        session.add(SkillMaster('skill_uuid1', '', '', '', ''))
-        session.add(SkillMaster('skill_uuid2', '', '', '', ''))
+        session.add(SkillMaster(uuid='skill_uuid1'))
+        session.add(SkillMaster(uuid='skill_uuid2'))
         session.commit()
         with utils.makeNamedTemporaryCSV(sample_ksas, separator='\t') as fname:
             load_skills_importance(fname, engine)

--- a/tests/api_sync/v1/test_skills_master.py
+++ b/tests/api_sync/v1/test_skills_master.py
@@ -6,20 +6,20 @@ from api_sync.v1.models import ensure_db
 from api_sync.v1.skills_master import load_skills_master
 
 sample_input = [
-    ['', 'O*NET-SOC Code', 'Element ID', 'ONET KSA', 'Description', 'skill_uuid', 'nlp_a'],
-    ['0', '11-1011.00', '2.a.1.a', 'reading comprehension', 'understanding written sentences and paragraphs in work related documents.', '2c77c703bd66e104c78b1392c3203362', 'reading comprehension'],
-    ['1', '11-1011.00', '2.a.1.b', 'active listening', 'giving full attention to what other people are saying, taking time to understand the points being made, asking questions as appropriate, and not interrupting at inappropriate times.', 'a636cb69257dcec699bce4f023a05126', 'active listening'],
-    ['2', '11-1011.00', '2.a.1.c', 'writing', 'communicating effectively in writing as appropriate for the needs of the audience.', '1cea5345d284f36245a94301b114b27c', 'writing'],
-    ['3', '11-1011.00', '2.a.1.d', 'speaking', 'talking to others to convey information effectively.', 'd1715efc5a67ac1c988152b8136e3dfa', 'speaking'],
-    ['4', '11-1011.00', '2.a.1.e', 'mathematics', 'using mathematics to solve problems.', '6ae28a55456b101be8261e5dee44cd3e', 'mathematics'],
-    ['5', '11-1011.00', '2.a.1.f', 'science', 'using scientific rules and methods to solve problems.', 'fb5c7f9bb4b32ce2f3bff4662f1ab27b', 'science'],
-    ['6', '11-1011.00', '2.a.2.a', 'critical thinking', 'using logic and reasoning to identify the strengths and weaknesses of alternative solutions,  conclusions or approaches to problems.', '20784bf09c9fe614603ad635e6093ede', 'critical thinking'],
-    ['7', '11-1011.00', '2.a.2.b', 'active learning', 'understanding the implications of new information for both current and future problem-solving and decision-making.', 'e98ada9866a495536ba6348ccec73915', 'active learning'],
+    ['', 'O*NET-SOC Code', 'Element ID', 'ONET KSA', 'ksa_type', 'Description', 'skill_uuid', 'nlp_a'],
+    ['0', '11-1011.00', '2.a.1.a', 'reading comprehension', 'skill', 'understanding written sentences and paragraphs in work related documents.', '2c77c703bd66e104c78b1392c3203362', 'reading comprehension'],
+    ['1', '11-1011.00', '2.a.1.b', 'active listening', 'skill', 'giving full attention to what other people are saying, taking time to understand the points being made, asking questions as appropriate, and not interrupting at inappropriate times.', 'a636cb69257dcec699bce4f023a05126', 'active listening'],
+    ['2', '11-1011.00', '2.a.1.c', 'writing', 'skill', 'communicating effectively in writing as appropriate for the needs of the audience.', '1cea5345d284f36245a94301b114b27c', 'writing'],
+    ['3', '11-1011.00', '2.a.1.d', 'speaking', 'skill', 'talking to others to convey information effectively.', 'd1715efc5a67ac1c988152b8136e3dfa', 'speaking'],
+    ['4', '11-1011.00', '2.a.1.e', 'mathematics', 'skill', 'using mathematics to solve problems.', '6ae28a55456b101be8261e5dee44cd3e', 'mathematics'],
+    ['5', '11-1011.00', '2.a.1.f', 'science', 'skill', 'using scientific rules and methods to solve problems.', 'fb5c7f9bb4b32ce2f3bff4662f1ab27b', 'science'],
+    ['6', '11-1011.00', '2.a.2.a', 'critical thinking', 'skill', 'using logic and reasoning to identify the strengths and weaknesses of alternative solutions,  conclusions or approaches to problems.', '20784bf09c9fe614603ad635e6093ede', 'critical thinking'],
+    ['7', '11-1011.00', '2.a.2.b', 'active learning', 'ability', 'understanding the implications of new information for both current and future problem-solving and decision-making.', 'e98ada9866a495536ba6348ccec73915', 'active learning'],
 ]
 
 new_input = [
-    ['', 'O*NET-SOC Code', 'Element ID', 'ONET KSA', 'Description', 'skill_uuid', 'nlp_a'],
-    ['0', '11-1011.00', '2.a.1.a', 'reading comprehension', 'an updated description', '2c77c703bd66e104c78b1392c3203362', 'reading comprehension'],
+    ['', 'O*NET-SOC Code', 'Element ID', 'ONET KSA', 'ksa_type', 'Description', 'skill_uuid', 'nlp_a'],
+    ['0', '11-1011.00', '2.a.1.a', 'reading comprehension', 'skill', 'an updated description', '2c77c703bd66e104c78b1392c3203362', 'reading comprehension'],
 
 ]
 

--- a/tests/test_skill_extractors.py
+++ b/tests/test_skill_extractors.py
@@ -87,6 +87,11 @@ def test_onet_skill_extractor():
         # -1 row that is a dupe
         assert len(output) == 7
 
+        assert len([row for row in output if row['ksa_type'] == 'knowledge']) == 2
+        assert len([row for row in output if row['ksa_type'] == 'skill']) == 1
+        assert len([row for row in output if row['ksa_type'] == 'ability']) == 1
+        assert len([row for row in output if row['ksa_type'] == 'tool']) == 3
+
         # make sure uuid is hashed version of the KSA
         for row in output:
             assert row['skill_uuid'] == md5(row['ONET KSA'])

--- a/utils/db.py
+++ b/utils/db.py
@@ -5,9 +5,17 @@ import yaml
 
 
 def get_apiv1_dbengine():
+    return create_engine(get_apiv1_dburl())
+
+
+def get_apiv1_dburl():
     dburl = os.environ.get('API_V1_DB_URL', None)
     if not dburl:
-        config_filename = 'api_v1_db_config.yaml'
+        config_filename = os.path.join(
+            os.path.dirname(__file__),
+            '../',
+            'api_v1_db_config.yaml'
+        )
 
         with open(config_filename) as f:
             config = yaml.load(f)
@@ -19,4 +27,4 @@ def get_apiv1_dbengine():
                 'port': config['PGPORT'],
             }
             dburl = URL('postgres', **dbconfig)
-    return create_engine(dburl)
+    return dburl


### PR DESCRIPTION
- Add alembic to repo to track schema migrations
- Abstract sqlalchemy connection url so it is available to Alembic config
- Add ksa_type to SkillMaster model, and create migration to add column
- Remove SkillMaster constructor so we can just use kwargs
- Populate ksa_type column in onet_ksa SkillExtractors CSV output
- Populate ksa_type column in skills_master_loader