### PR TITLE
Make the S3 /skills-public/pipeline/tables cleaner again

### DIFF
--- a/dags/geo_title_counts.py
+++ b/dags/geo_title_counts.py
@@ -36,11 +36,11 @@ class GeoTitleCountOperator(BaseOperator):
     def execute(self, context):
         s3_conn = S3Hook().get_conn()
         quarter = datetime_to_quarter(context['execution_date'])
-        count_filename = '{}/geo_title_count_{}.csv'.format(
+        count_filename = '{}/geo_title_count/{}.csv'.format(
             output_folder,
             quarter
         )
-        rollup_filename = '{}/title_count_{}.csv'.format(
+        rollup_filename = '{}/title_count/{}.csv'.format(
             output_folder,
             quarter
         )
@@ -79,22 +79,22 @@ class JobTitleCleanOperator(BaseOperator):
         s3_conn = S3Hook().get_conn()
         quarter = datetime_to_quarter(context['execution_date'])
 
-        cleaned_count_filename = '{}/cleaned_geo_title_count_{}_new.csv'.format(
+        cleaned_count_filename = '{}/cleaned_geo_title_count/{}.csv'.format(
             output_folder,
             quarter
         )
 
-        cleaned_rollup_filename = '{}/cleaned_title_count_{}.csv'.format(
+        cleaned_rollup_filename = '{}/cleaned_title_count/{}.csv'.format(
             output_folder,
             quarter
         )
 
-        count_filename = '{}/geo_title_count_{}.csv'.format(
+        count_filename = '{}/geo_title_count/{}.csv'.format(
             output_folder,
             quarter
         )
 
-        rollup_filename = '{}/title_count_{}.csv'.format(
+        rollup_filename = '{}/title_count/{}.csv'.format(
             output_folder,
             quarter
         )

--- a/tests/test_utils_fs.py
+++ b/tests/test_utils_fs.py
@@ -1,7 +1,7 @@
-from utils.fs import cache_json, CACHE_DIRECTORY
+from utils.fs import cache_json, CACHE_DIRECTORY, check_create_folder
 import os
 import json
-
+import shutil
 
 def test_cache_json():
     counter = {'times_called': 0}
@@ -20,3 +20,10 @@ def test_cache_json():
     # run the function again and make sure the cached version is used
     assert a_function(counter) == '6'
     assert counter['times_called'] == 1
+
+def test_check_create_folder():
+    test_dir = 'test_dir'
+    filename = os.path.join(test_dir, 'test.txt')
+    check_create_folder(filename)
+    assert os.path.exists(test_dir) == True
+    shutil.rmtree(test_dir)

--- a/utils/fs.py
+++ b/utils/fs.py
@@ -22,3 +22,7 @@ def cache_json(filename):
                 return function_output
         return cache_wrapper
     return cache_decorator
+
+def check_create_folder(filename):
+    """Check if the folder exisits. If not, create the folder"""
+    os.makedirs(os.path.dirname(filename), exist_ok=True)


### PR DESCRIPTION
Basically this PR is to put each type of geo_title_count or title_count into their own folders to make our S3 more organized. 
I'm doing the job_title_sampler now, and will PR another branch after this PR get merged. 