### PR TITLE
Include CBSA Name and State in aggregations [Resolves #59]

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,7 @@
 codecov
 httpretty==0.8.10
 mock
-mock
-moto
+moto<1.0
 pytest-cov
 pytest
 Sphinx

--- a/skills_ml/algorithms/aggregators/title.py
+++ b/skills_ml/algorithms/aggregators/title.py
@@ -25,7 +25,7 @@ class GeoTitleAggregator(object):
         Returns:
             (collections.Counter)
                 The number of job postings for each
-                (CBSA FIPS Code, Job Title) tuple
+                (CBSA FIPS Code, CBSA Name, State Code, Job Title) tuple
         """
         counts = Counter()
         title_rollup = Counter()
@@ -34,11 +34,13 @@ class GeoTitleAggregator(object):
             job_title = self.title_cleaner(job_posting['title'])
             title_rollup[job_title] += 1
             hits = self.geo_querier.query(job_posting)
-            for cbsa_fips in hits:
-                counts[(cbsa_fips, job_title)] += 1
+            for cbsa_fips, cbsa_name, state_code in hits:
+                counts[(cbsa_fips, cbsa_name, state_code, job_title)] += 1
                 logging.info(
-                    '%s, %s, %s',
+                    '%s, %s, %s, %s, %s',
                     cbsa_fips,
+                    cbsa_name,
+                    state_code,
                     job_title,
                     counts[(cbsa_fips, job_title)]
                 )

--- a/skills_ml/algorithms/job_geography_queriers/cbsa.py
+++ b/skills_ml/algorithms/job_geography_queriers/cbsa.py
@@ -64,5 +64,6 @@ class JobCBSAQuerier(object):
             return []
 
         hits = self.ua_cbsa[ua_fips]
+        hits = [hit + (state_code,) for hit in hits]
         logging.info('Found %s hits, %s', len(hits), hits)
         return hits

--- a/skills_ml/datasets/ua_cbsa.py
+++ b/skills_ml/datasets/ua_cbsa.py
@@ -12,9 +12,9 @@ URL = 'http://www2.census.gov/geo/docs/maps-data/data/rel/ua_cbsa_rel_10.txt'
 @cache_json('ua_cbsa_lookup.json')
 def ua_cbsa():
     """
-    Construct a Place->UA Lookup table from Census data
+    Construct a UA->CBSA Lookup table from Census data
     Returns: dict
-    { UA Fips: [CBSA FIPS] }
+    { UA Fips: [(CBSA FIPS, CBSA Name)] }
     """
     logging.info("Beginning CBSA lookup")
     lookup = defaultdict(list)
@@ -31,12 +31,13 @@ def ua_cbsa():
         total += 1
         ua_fips = row[0]
         cbsa_fips = row[2]
+        cbsa_name = row[3]
 
         if cbsa_fips == '99999' or ua_fips == '99999':
             not_designated += 1
             continue
 
-        lookup[ua_fips].append(cbsa_fips)
+        lookup[ua_fips].append((cbsa_fips, cbsa_name))
 
         logging.info(
             'Done extracting CBSAs %s total rows, %s not designated, %s found',

--- a/tests/test_datasets_ua_cbsa.py
+++ b/tests/test_datasets_ua_cbsa.py
@@ -22,6 +22,9 @@ def test_ua_cbsa():
 
     results = ua_cbsa.__wrapped__()
     assert results == {
-        '00037': ['10020', '35340'],
-        '00091': ['48140']
+        '00037': [
+            ('10020', 'Abbeville, LA Micro Area'),
+            ('35340', 'New Iberia, LA Micro Area'),
+        ],
+        '00091': [('48140', 'Wausau, WI Metro Area')]
     }

--- a/tests/test_job_geo_queriers.py
+++ b/tests/test_job_geo_queriers.py
@@ -10,10 +10,13 @@ cousub_ua_lookup = {
     'ND': {'elgin': '623'}
 }
 ua_cbsa_lookup = {
-    '123': ['456'],
-    '234': ['678'],
-    '823': ['987', '876'],
-    '623': ['345']
+    '123': [('456', 'Chicago, IL Metro Area')],
+    '234': [('678', 'Rockford, IL Metro Area')],
+    '823': [
+        ('987', 'Springfield, MA Metro Area'),
+        ('876', 'Worcester, MA Metro Area'),
+    ],
+    '623': [('345', 'Fargo, ND Metro Area')]
 }
 
 
@@ -48,7 +51,9 @@ class CBSATest(unittest.TestCase):
             "id": 5
         }
 
-        assert self.querier.query(sample_job) == ['456']
+        assert self.querier.query(sample_job) == [
+            ('456', 'Chicago, IL Metro Area', 'IL'),
+        ]
 
     def test_querier_multiple_hits(self):
         sample_job = {
@@ -68,7 +73,10 @@ class CBSATest(unittest.TestCase):
             "id": 5
         }
 
-        assert self.querier.query(sample_job) == ['987', '876']
+        assert self.querier.query(sample_job) == [
+            ('987', 'Springfield, MA Metro Area', 'MA'),
+            ('876', 'Worcester, MA Metro Area', 'MA'),
+        ]
 
     def test_querier_no_hits(self):
         sample_job = {
@@ -108,7 +116,7 @@ class CBSATest(unittest.TestCase):
             "id": 5
         }
 
-        assert self.querier.query(sample_job) == ['345']
+        assert self.querier.query(sample_job) == [('345', 'Fargo, ND Metro Area', 'ND')]
 
     def test_querier_blank(self):
         assert self.querier.query({'id': 5}) == []

--- a/tests/test_title_aggregators.py
+++ b/tests/test_title_aggregators.py
@@ -7,9 +7,12 @@ from skills_ml.algorithms.string_cleaners import NLPTransforms
 class FakeCBSAQuerier(object):
     def query(self, job_listing):
         if job_listing['id'] == 1:
-            return ['123', '234']
+            return [
+                ('123', 'Another Metro', 'YY'),
+                ('234', 'A Micro', 'ZY')
+            ]
         else:
-            return ['456']
+            return [('456', 'A Metro', 'XX')]
 
 SAMPLE_JOBS = [
     {'id': 1, 'title': 'Cupcake Ninja'},
@@ -27,10 +30,10 @@ def test_geo_title_aggregator():
         [json.dumps(job) for job in SAMPLE_JOBS]
     )
     assert counts == {
-        ('456', 'Regular Ninja'): 1,
-        ('456', 'React Ninja'): 2,
-        ('123', 'Cupcake Ninja'): 1,
-        ('234', 'Cupcake Ninja'): 1
+        ('456', 'A Metro', 'XX', 'Regular Ninja'): 1,
+        ('456', 'A Metro', 'XX', 'React Ninja'): 2,
+        ('123', 'Another Metro', 'YY', 'Cupcake Ninja'): 1,
+        ('234', 'A Micro', 'ZY', 'Cupcake Ninja'): 1
     }
 
     assert title_rollup == {
@@ -50,10 +53,10 @@ def test_geo_title_aggregator_with_cleaning():
         [json.dumps(job) for job in SAMPLE_JOBS]
     )
     assert counts == {
-        ('456', 'regular ninja'): 1,
-        ('456', 'react ninja'): 2,
-        ('123', 'cupcake ninja'): 1,
-        ('234', 'cupcake ninja'): 1
+        ('456', 'A Metro', 'XX', 'regular ninja'): 1,
+        ('456', 'A Metro', 'XX', 'react ninja'): 2,
+        ('123', 'Another Metro', 'YY', 'cupcake ninja'): 1,
+        ('234', 'A Micro', 'ZY', 'cupcake ninja'): 1
     }
 
     assert title_rollup == {


### PR DESCRIPTION
- Add CBSA name along with FIPS to Urbanized Area Crosswalk, Job Geography Querier, and Title Aggregator