### PR TITLE
Extract and Aggregate Skills from Job Postings [Resolves #63]

### DIFF
--- a/skills_ml/algorithms/README.md
+++ b/skills_ml/algorithms/README.md
@@ -20,7 +20,7 @@ algorithms
 
 - `representativeness_calculators` - Methods for calculating geographic representativeness of SOC Codes.
 
-- `skill_extractors` - Methods for creating a skills CSV based on ONET data.
+- `skill_extractors` - Methods for extracting skills from structured or unstructured data sources
 
 - `skill_importance_extractors` - Methods for creating a skills importance CSV based on ONET data.
 

--- a/skills_ml/algorithms/aggregators/__init__.py
+++ b/skills_ml/algorithms/aggregators/__init__.py
@@ -16,12 +16,12 @@ class JobAggregator(object):
             job_posting (dict) a job postings in common schema format
             job_key (str) an element of the job posting (say, a title) that is
                 being used for aggregation
-            groups (iterable of tuples) the aggregatable groups (say, CBSAs)
+            groups (iterable) the aggregatable groups (say, CBSAs)
                 that this job posting belongs to
         """
         value = self.value(job_posting)
         for group_key in groups:
-            full_key = group_key + (job_key,)
+            full_key = (group_key, job_key)
             self.group_values[full_key] += value
         self.rollup[job_key] += value
 

--- a/skills_ml/algorithms/aggregators/__init__.py
+++ b/skills_ml/algorithms/aggregators/__init__.py
@@ -1,0 +1,60 @@
+from collections import Counter, defaultdict
+
+
+class JobAggregator(object):
+    def __init__(self):
+        self.initialize_counts()
+
+    def initialize_counts(self):
+        self.group_values = defaultdict(Counter)
+        self.rollup = defaultdict(Counter)
+
+    def accumulate(self, job_posting, job_key, groups):
+        """Incorporates the data from a single job posting
+
+        Args:
+            job_posting (dict) a job postings in common schema format
+            job_key (str) an element of the job posting (say, a title) that is
+                being used for aggregation
+            groups (iterable of tuples) the aggregatable groups (say, CBSAs)
+                that this job posting belongs to
+        """
+        value = self.value(job_posting)
+        for group_key in groups:
+            full_key = group_key + (job_key,)
+            self.group_values[full_key] += value
+        self.rollup[job_key] += value
+
+    def value(self, job_posting):
+        raise NotImplementedError
+
+
+class CountAggregator(JobAggregator):
+    """Counts job postings"""
+
+    def initialize_counts(self):
+        self.group_values = Counter()
+        self.rollup = Counter()
+
+    def value(self, job_posting):
+        return 1
+
+
+class SkillAggregator(JobAggregator):
+    """Aggregates skills found in job postings
+
+    Args:
+        skill_extractor (.skill_extractors.FreetextSkillExtractor)
+            an object that returns skill counts from unstructured text
+        corpus creator (object) an object that returns a text corpus
+            from a job posting
+    """
+    def __init__(self, skill_extractor, corpus_creator):
+        super(SkillAggregator, self).__init__()
+        self.skill_extractor = skill_extractor
+        self.corpus_creator = corpus_creator
+
+    def value(self, job_posting):
+        return self.skill_extractor.document_skill_counts(
+            self.corpus_creator._transform(job_posting)
+        )

--- a/skills_ml/algorithms/corpus_creators/basic.py
+++ b/skills_ml/algorithms/corpus_creators/basic.py
@@ -74,7 +74,7 @@ class SimpleCorpusCreator(CorpusCreator):
 
     def _transform(self, document):
         return self.join_spaces([
-            self.nlp.lowercase_strip_punc(document[field])
+            self.nlp.lowercase_strip_punc(document.get(field, ''))
             for field in self.document_schema_fields
         ])
 

--- a/skills_ml/algorithms/job_geography_queriers/cbsa.py
+++ b/skills_ml/algorithms/job_geography_queriers/cbsa.py
@@ -19,6 +19,10 @@ class JobCBSAQuerier(object):
     """
     Queries the Core-Based Statistical Area for a job
     """
+
+    # The columns that are returned for each row
+    geo_key_names = ('cbsa_fips', 'cbsa_name', 'state_code')
+
     def __init__(self):
         self.ua_cbsa = ua_cbsa()
         self.place_ua = place_ua(city_cleaner)

--- a/skills_ml/algorithms/skill_extractors/freetext.py
+++ b/skills_ml/algorithms/skill_extractors/freetext.py
@@ -1,0 +1,86 @@
+import csv
+import logging
+from collections import Counter
+
+from skills_ml.algorithms.string_cleaners import NLPTransforms
+
+
+class FreetextSkillExtractor(object):
+    """Extract skills from unstructured text
+
+    Originally written by Kwame Porter Robinson
+    """
+    def __init__(self, skills_filename):
+        self.skills_filename = skills_filename
+        self.tracker = {
+            'total_skills': 0,
+            'jobs_with_skills': 0
+        }
+        self.nlp = NLPTransforms()
+        self.lookup = self._skills_lookup()
+        logging.info(
+            'Done creating skills lookup with %d entries',
+            len(self.lookup)
+        )
+
+    def _skills_lookup(self):
+        """Create skills lookup
+
+        Reads the object's filename containing skills into a lookup
+
+        Returns: (set) skill names
+        """
+        logging.info('Creating skills lookup from %s', self.skills_filename)
+        with open(self.skills_filename) as infile:
+            reader = csv.reader(infile, delimiter='\t')
+            header = next(reader)
+            index = header.index(self.nlp.transforms[0])
+            generator = (row[index] for row in reader)
+            return set(generator)
+
+    def document_skill_counts(self, document):
+        """Count skills in the document
+
+        Args:
+            document (string) A document for searching, such as a job posting
+
+        Returns: (collections.Counter) skills found in the document, all
+            values set to 1 (multiple occurrences of a skill do not count)
+        """
+        join_spaces = " ".join  # for runtime efficiency
+        N = 5
+        doc = document.split()
+        doc_len = len(doc)
+        skills = Counter()
+
+        start_idx = 0
+
+        while start_idx < doc_len:
+            offset = 1
+
+            lookahead = min(N, doc_len - start_idx)
+            for idx in range(lookahead, 0, -1):
+                ngram = join_spaces(doc[start_idx:start_idx+idx])
+                if ngram in self.lookup:
+                    skills[ngram] = 1
+                    offset = idx
+                    break
+
+            start_idx += offset
+        return skills
+
+
+class FakeFreetextSkillExtractor(FreetextSkillExtractor):
+    """A skill extractor that takes a list of skills
+    instead of reading from a filename
+    """
+    def __init__(self, skills):
+        """
+        Args:
+            skills (list) skill names that the extractor should use
+        """
+        self.skills = skills
+        super(FakeFreetextSkillExtractor, self).__init__('')
+
+    def _skills_lookup(self):
+        return set(self.skills)

--- a/tests/test_title_aggregators.py
+++ b/tests/test_title_aggregators.py
@@ -42,10 +42,10 @@ def test_geo_title_aggregator():
     aggregator.process_postings([json.dumps(job) for job in SAMPLE_JOBS])
 
     assert aggregator.job_aggregators['count'].group_values == {
-        ('456', 'A Metro', 'XX', 'Regular Ninja'): 1,
-        ('456', 'A Metro', 'XX', 'React Ninja'): 2,
-        ('123', 'Another Metro', 'YY', 'Cupcake Ninja'): 1,
-        ('234', 'A Micro', 'ZY', 'Cupcake Ninja'): 1
+        (('456', 'A Metro', 'XX'), 'Regular Ninja'): 1,
+        (('456', 'A Metro', 'XX'), 'React Ninja'): 2,
+        (('123', 'Another Metro', 'YY'), 'Cupcake Ninja'): 1,
+        (('234', 'A Micro', 'ZY'), 'Cupcake Ninja'): 1
     }
 
     assert aggregator.job_aggregators['count'].rollup == {
@@ -55,10 +55,10 @@ def test_geo_title_aggregator():
     }
 
     assert aggregator.job_aggregators['skills'].group_values == {
-        ('123', 'Another Metro', 'YY', 'Cupcake Ninja'): {'slicing': 1, 'dicing': 1},
-        ('234', 'A Micro', 'ZY', 'Cupcake Ninja'): {'slicing': 1, 'dicing': 1},
-        ('456', 'A Metro', 'XX', 'Regular Ninja'): {'slicing': 1, 'dicing': 1},
-        ('456', 'A Metro', 'XX', 'React Ninja'): {'slicing': 2, 'dicing': 2, 'jquery': 1}
+        (('123', 'Another Metro', 'YY'), 'Cupcake Ninja'): {'slicing': 1, 'dicing': 1},
+        (('234', 'A Micro', 'ZY'), 'Cupcake Ninja'): {'slicing': 1, 'dicing': 1},
+        (('456', 'A Metro', 'XX'), 'Regular Ninja'): {'slicing': 1, 'dicing': 1},
+        (('456', 'A Metro', 'XX'), 'React Ninja'): {'slicing': 2, 'dicing': 2, 'jquery': 1}
     }
 
     assert aggregator.job_aggregators['skills'].rollup == {
@@ -87,10 +87,10 @@ def test_geo_title_aggregator_with_cleaning():
     aggregator.process_postings([json.dumps(job) for job in SAMPLE_JOBS])
 
     assert aggregator.job_aggregators['count'].group_values == {
-        ('456', 'A Metro', 'XX', 'regular ninja'): 1,
-        ('456', 'A Metro', 'XX', 'react ninja'): 2,
-        ('123', 'Another Metro', 'YY', 'cupcake ninja'): 1,
-        ('234', 'A Micro', 'ZY', 'cupcake ninja'): 1
+        (('456', 'A Metro', 'XX'), 'regular ninja'): 1,
+        (('456', 'A Metro', 'XX'), 'react ninja'): 2,
+        (('123', 'Another Metro', 'YY'), 'cupcake ninja'): 1,
+        (('234', 'A Micro', 'ZY'), 'cupcake ninja'): 1
     }
 
     assert aggregator.job_aggregators['count'].rollup == {
@@ -100,10 +100,10 @@ def test_geo_title_aggregator_with_cleaning():
     }
 
     assert aggregator.job_aggregators['skills'].group_values == {
-        ('123', 'Another Metro', 'YY', 'cupcake ninja'): {'slicing': 1, 'dicing': 1},
-        ('234', 'A Micro', 'ZY', 'cupcake ninja'): {'slicing': 1, 'dicing': 1},
-        ('456', 'A Metro', 'XX', 'regular ninja'): {'slicing': 1, 'dicing': 1},
-        ('456', 'A Metro', 'XX', 'react ninja'): {'slicing': 2, 'dicing': 2, 'jquery': 1}
+        (('123', 'Another Metro', 'YY'), 'cupcake ninja'): {'slicing': 1, 'dicing': 1},
+        (('234', 'A Micro', 'ZY'), 'cupcake ninja'): {'slicing': 1, 'dicing': 1},
+        (('456', 'A Metro', 'XX'), 'regular ninja'): {'slicing': 1, 'dicing': 1},
+        (('456', 'A Metro', 'XX'), 'react ninja'): {'slicing': 2, 'dicing': 2, 'jquery': 1}
     }
 
     assert aggregator.job_aggregators['skills'].rollup == {

--- a/tests/test_title_aggregators.py
+++ b/tests/test_title_aggregators.py
@@ -1,7 +1,10 @@
 import json
 
+from skills_ml.algorithms.aggregators import SkillAggregator, CountAggregator
 from skills_ml.algorithms.aggregators.title import GeoTitleAggregator
 from skills_ml.algorithms.string_cleaners import NLPTransforms
+from skills_ml.algorithms.skill_extractors.freetext import FakeFreetextSkillExtractor
+from skills_ml.algorithms.corpus_creators.basic import SimpleCorpusCreator
 
 
 class FakeCBSAQuerier(object):
@@ -15,52 +18,96 @@ class FakeCBSAQuerier(object):
             return [('456', 'A Metro', 'XX')]
 
 SAMPLE_JOBS = [
-    {'id': 1, 'title': 'Cupcake Ninja'},
-    {'id': 2, 'title': 'Regular Ninja'},
-    {'id': 3, 'title': 'React Ninja'},
-    {'id': 4, 'title': 'React Ninja'},
+    {'id': 1, 'title': 'Cupcake Ninja', 'description': 'Slicing and dicing frosting'},
+    {'id': 2, 'title': 'Regular Ninja', 'description': 'Slicing and dicing enemies'},
+    {'id': 3, 'title': 'React Ninja', 'description': 'Slicing and dicing components'},
+    {'id': 4, 'title': 'React Ninja', 'description': 'Slicing and dicing and then trashing jQuery'},
 ]
 
 
 def test_geo_title_aggregator():
+    job_aggregators = {
+        'skills': SkillAggregator(
+            skill_extractor=FakeFreetextSkillExtractor(
+                skills=['slicing', 'dicing', 'jquery']
+            ),
+            corpus_creator=SimpleCorpusCreator()
+        ),
+        'count': CountAggregator(),
+    }
     aggregator = GeoTitleAggregator(
-        geo_querier=FakeCBSAQuerier(),
+        job_aggregators=job_aggregators,
+        geo_querier=FakeCBSAQuerier()
     )
-    counts, title_rollup = aggregator.counts(
-        [json.dumps(job) for job in SAMPLE_JOBS]
-    )
-    assert counts == {
+    aggregator.process_postings([json.dumps(job) for job in SAMPLE_JOBS])
+
+    assert aggregator.job_aggregators['count'].group_values == {
         ('456', 'A Metro', 'XX', 'Regular Ninja'): 1,
         ('456', 'A Metro', 'XX', 'React Ninja'): 2,
         ('123', 'Another Metro', 'YY', 'Cupcake Ninja'): 1,
         ('234', 'A Micro', 'ZY', 'Cupcake Ninja'): 1
     }
 
-    assert title_rollup == {
+    assert aggregator.job_aggregators['count'].rollup == {
         'Cupcake Ninja': 1,
         'Regular Ninja': 1,
         'React Ninja': 2,
     }
 
+    assert aggregator.job_aggregators['skills'].group_values == {
+        ('123', 'Another Metro', 'YY', 'Cupcake Ninja'): {'slicing': 1, 'dicing': 1},
+        ('234', 'A Micro', 'ZY', 'Cupcake Ninja'): {'slicing': 1, 'dicing': 1},
+        ('456', 'A Metro', 'XX', 'Regular Ninja'): {'slicing': 1, 'dicing': 1},
+        ('456', 'A Metro', 'XX', 'React Ninja'): {'slicing': 2, 'dicing': 2, 'jquery': 1}
+    }
+
+    assert aggregator.job_aggregators['skills'].rollup == {
+        'Cupcake Ninja': {'slicing': 1, 'dicing': 1},
+        'Regular Ninja': {'slicing': 1, 'dicing': 1},
+        'React Ninja': {'slicing': 2, 'dicing': 2, 'jquery': 1}
+    }
+
 
 def test_geo_title_aggregator_with_cleaning():
     nlp = NLPTransforms()
+    job_aggregators = {
+        'skills': SkillAggregator(
+            skill_extractor=FakeFreetextSkillExtractor(
+                skills=['slicing', 'dicing', 'jquery']
+            ),
+            corpus_creator=SimpleCorpusCreator()
+        ),
+        'count': CountAggregator(),
+    }
     aggregator = GeoTitleAggregator(
+        job_aggregators=job_aggregators,
         geo_querier=FakeCBSAQuerier(),
-        title_cleaner=nlp.lowercase_strip_punc
+        title_cleaner=nlp.lowercase_strip_punc,
     )
-    counts, title_rollup = aggregator.counts(
-        [json.dumps(job) for job in SAMPLE_JOBS]
-    )
-    assert counts == {
+    aggregator.process_postings([json.dumps(job) for job in SAMPLE_JOBS])
+
+    assert aggregator.job_aggregators['count'].group_values == {
         ('456', 'A Metro', 'XX', 'regular ninja'): 1,
         ('456', 'A Metro', 'XX', 'react ninja'): 2,
         ('123', 'Another Metro', 'YY', 'cupcake ninja'): 1,
         ('234', 'A Micro', 'ZY', 'cupcake ninja'): 1
     }
 
-    assert title_rollup == {
+    assert aggregator.job_aggregators['count'].rollup == {
         'cupcake ninja': 1,
         'regular ninja': 1,
         'react ninja': 2,
+    }
+
+    assert aggregator.job_aggregators['skills'].group_values == {
+        ('123', 'Another Metro', 'YY', 'cupcake ninja'): {'slicing': 1, 'dicing': 1},
+        ('234', 'A Micro', 'ZY', 'cupcake ninja'): {'slicing': 1, 'dicing': 1},
+        ('456', 'A Metro', 'XX', 'regular ninja'): {'slicing': 1, 'dicing': 1},
+        ('456', 'A Metro', 'XX', 'react ninja'): {'slicing': 2, 'dicing': 2, 'jquery': 1}
+    }
+
+    assert aggregator.job_aggregators['skills'].rollup == {
+        'cupcake ninja': {'slicing': 1, 'dicing': 1},
+        'regular ninja': {'slicing': 1, 'dicing': 1},
+        'react ninja': {'slicing': 2, 'dicing': 2, 'jquery': 1}
     }


### PR DESCRIPTION
There are a few changes in here worth calling out that I'm not sure about. Suggestions welcome.

1. Given that we are adding more and more things into the title aggregation (this isn't the last thing we'll put in here!), I decided that positional return values just aren't going to cut it anymore.  So I introduced the `Aggregation`, which is for presenting the same data at different rollup levels. Right now it's `.by_geo` and `.rollup`, but I can see this getting broken up into `.by_cbsa`, `.by_state`, etc in the future. 

I also introduced `AllAggregations`, a container for multiple `Aggregation` you would want to access. So in here there are currently counts and skills, but soon we'll put in SOC codes, etc. The Aggregator just returns one of the `AllAggregations` objects, and the caller can parse that.

I'm not sure that this is the exact structure that would be easiest to use, but I figured this would be an improvement over returning a tuple.

2.  The other is calling this a 'Skill Extractor'. I realized that 'Skill Tagging', the way this code exists already, is specifically for returning the original full text with the skills tagged in it. This is not what we are doing here. `algorithms.skill_extractors` currently has the ONET skill table maker, which is a different purpose than this. But I do think that this does fit in a little closer with 'Skill Extractors', which I redefined in the README.

- Add FreetextSkillExtractor to return base skill counts for a document
- Modify GeoTitleAggregator to include skill counts in results
- Introduce Aggregation and AllAggregations objects to contain aggregation results of varying types