### PR TITLE
JobGeographyQuerier expects lists, not tuples

### DIFF
--- a/skills_ml/algorithms/job_geography_queriers/cbsa.py
+++ b/skills_ml/algorithms/job_geography_queriers/cbsa.py
@@ -68,6 +68,6 @@ class JobCBSAQuerier(object):
             return []
 
         hits = self.ua_cbsa[ua_fips]
-        hits = [hit + (state_code,) for hit in hits]
+        hits = [hit + [state_code] for hit in hits]
         logging.info('Found %s hits, %s', len(hits), hits)
         return hits

--- a/tests/test_job_geo_queriers.py
+++ b/tests/test_job_geo_queriers.py
@@ -10,13 +10,13 @@ cousub_ua_lookup = {
     'ND': {'elgin': '623'}
 }
 ua_cbsa_lookup = {
-    '123': [('456', 'Chicago, IL Metro Area')],
-    '234': [('678', 'Rockford, IL Metro Area')],
+    '123': [['456', 'Chicago, IL Metro Area']],
+    '234': [['678', 'Rockford, IL Metro Area']],
     '823': [
-        ('987', 'Springfield, MA Metro Area'),
-        ('876', 'Worcester, MA Metro Area'),
+        ['987', 'Springfield, MA Metro Area'],
+        ['876', 'Worcester, MA Metro Area'],
     ],
-    '623': [('345', 'Fargo, ND Metro Area')]
+    '623': [['345', 'Fargo, ND Metro Area']]
 }
 
 
@@ -52,7 +52,7 @@ class CBSATest(unittest.TestCase):
         }
 
         assert self.querier.query(sample_job) == [
-            ('456', 'Chicago, IL Metro Area', 'IL'),
+            ['456', 'Chicago, IL Metro Area', 'IL'],
         ]
 
     def test_querier_multiple_hits(self):
@@ -74,8 +74,8 @@ class CBSATest(unittest.TestCase):
         }
 
         assert self.querier.query(sample_job) == [
-            ('987', 'Springfield, MA Metro Area', 'MA'),
-            ('876', 'Worcester, MA Metro Area', 'MA'),
+            ['987', 'Springfield, MA Metro Area', 'MA'],
+            ['876', 'Worcester, MA Metro Area', 'MA'],
         ]
 
     def test_querier_no_hits(self):
@@ -116,7 +116,7 @@ class CBSATest(unittest.TestCase):
             "id": 5
         }
 
-        assert self.querier.query(sample_job) == [('345', 'Fargo, ND Metro Area', 'ND')]
+        assert self.querier.query(sample_job) == [['345', 'Fargo, ND Metro Area', 'ND']]
 
     def test_querier_blank(self):
         assert self.querier.query({'id': 5}) == []


### PR DESCRIPTION
- Modify code and test for CBSA Job Querier to expect lists, not tuples