### PR TITLE
Support multiprocessing for aggregators [Resolves #77]

### DIFF
--- a/skills_ml/algorithms/aggregators/__init__.py
+++ b/skills_ml/algorithms/aggregators/__init__.py
@@ -11,6 +11,15 @@ class JobAggregator(object):
         self.group_values = defaultdict(Counter)
         self.rollup = defaultdict(Counter)
 
+    def __iadd__(self, other):
+        assert type(self) == type(other)
+        for key, value in other.group_values.items():
+            self.group_values[key] += value
+        for key, value in other.rollup.items():
+            self.rollup[key] += value
+
+        return self
+
     def accumulate(self, job_posting, job_key, groups):
         """Incorporates the data from a single job posting
 

--- a/skills_ml/algorithms/aggregators/geo.py
+++ b/skills_ml/algorithms/aggregators/geo.py
@@ -19,6 +19,11 @@ class GeoAggregator(object):
         self.job_aggregators = job_aggregators
         self.geo_querier = geo_querier or JobCBSAQuerier()
 
+    def merge_job_aggregators(self, other_job_aggregators):
+        for key, value in other_job_aggregators.items():
+            self.job_aggregators[key] += value
+        return self
+
     def process_postings(self, job_postings):
         raise NotImplementedError()
 

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -1,0 +1,16 @@
+from skills_ml.algorithms.aggregators import CountAggregator
+
+
+def test_addition():
+    first_aggregator = CountAggregator()
+    second_aggregator = CountAggregator()
+
+    first_aggregator.accumulate(job_posting='1', job_key=('1',), groups=['1'])
+    second_aggregator.accumulate(job_posting='2', job_key=('2',), groups=['2'])
+
+    first_aggregator += second_aggregator
+
+    assert first_aggregator.group_values == {
+        ('1', ('1',)): {'total': 1},
+        ('2', ('2',)): {'total': 1},
+    }


### PR DESCRIPTION
- Implement in-place addition for JobAggregator to add two similar JobAggregators (populated from different slices of job postings in different processes) together
- Implement merge_job_aggregators method for GeoAggregator to merge a collection of job aggregators (also populated in different processes) together
- Add test case for new merge functions but also another to make sure that all of it is multiprocessing-ready (specifically, that everything that needs to be able to pickle across the process boundary does so)
- PEP8-fix test_title_aggregators.py