### PR TITLE
Use state name instead of code for geocoding [Resolves #88]

### DIFF
--- a/skills_ml/algorithms/geocoders/__init__.py
+++ b/skills_ml/algorithms/geocoders/__init__.py
@@ -4,8 +4,11 @@ import logging
 import time
 import geocoder
 import boto
+import us
 
 from skills_utils.s3 import split_s3_path
+
+STATE_NAME_LOOKUP = us.states.mapping('abbr', 'name')
 
 
 def job_posting_search_string(job_posting):
@@ -24,7 +27,9 @@ def job_posting_search_string(job_posting):
     locality = location.get('address', {}).get('addressLocality', None)
     region = location.get('address', {}).get('addressRegion', None)
     if locality and region:
-        return '{}, {}'.format(locality, region)
+        # lookup state name, if it's not there just use whatever they typed
+        formatted_region = STATE_NAME_LOOKUP.get(region, region)
+        return '{}, {}'.format(locality, formatted_region)
     elif locality:
         return locality
     else:

--- a/tests/test_geocoders.py
+++ b/tests/test_geocoders.py
@@ -82,7 +82,17 @@ def test_job_posting_search_string():
     with open('sample_job_listing.json') as f:
         sample_job_posting = f.read()
 
-    assert job_posting_search_string(sample_job_posting) == 'Salisbury, PA'
+    assert job_posting_search_string(sample_job_posting) == 'Salisbury, Pennsylvania'
+
+
+def test_job_posting_weird_region():
+    fake_job = {'jobLocation': {'address': {
+        'addressLocality': 'Any City',
+        'addressRegion': 'Northeastern USA'
+    }}}
+
+    assert job_posting_search_string(json.dumps(fake_job)) ==\
+        'Any City, Northeastern USA'
 
 
 def test_job_posting_search_string_only_city():

--- a/tests/test_job_geo_queriers.py
+++ b/tests/test_job_geo_queriers.py
@@ -136,8 +136,8 @@ class CBSATest(unittest.TestCase):
 
 
 cbsa_results = {
-    'Elgin, IL': ['456', 'Chicago, IL Metro Area'],
-    'Elgin, TX': None,
+    'Elgin, Illinois': ['456', 'Chicago, IL Metro Area'],
+    'Elgin, Texas': None,
 }
 
 


### PR DESCRIPTION
- Convert state code to name if possible when geocoding
- Update all tests that expected geocode strings to use code