### PR TITLE
Training doc2vec

### DIFF
--- a/skills_ml/algorithms/occupation_classifiers/base.py
+++ b/skills_ml/algorithms/occupation_classifiers/base.py
@@ -8,6 +8,7 @@ from gensim.models import Doc2Vec
 
 from skills_utils.s3 import download, split_s3_path, list_files
 
+LOCAL_CACHE_DIRECTORY = 'tmp'
 
 class VectorModel(object):
     """The VectorModel Object is a base object which specifies which word-embeding model to be used in
@@ -63,7 +64,7 @@ class VectorModel(object):
             gensim.models.doc2vec.Doc2Vec: The word-embedding model object.
         """
         try:
-            model = Doc2Vec.load('tmp/' + self.model_name)
+            model = Doc2Vec.load(os.path.join(LOCAL_CACHE_DIRECTORY, self.model_name))
             return model
 
         except:
@@ -78,14 +79,14 @@ class VectorModel(object):
                     model = Doc2Vec.load(os.path.join(td, self.model_name))
 
             else:
-                if not os.path.isdir('tmp'):
-                    os.mkdir('tmp')
+                if not os.path.isdir(LOCAL_CACHE_DIRECTORY):
+                    os.mkdir(LOCAL_CACHE_DIRECTORY)
                 for f in files:
-                    filepath = 'tmp/' + f
+                    filepath = os.path.join(LOCAL_CACHE_DIRECTORY, f)
                     if not os.path.exists(filepath) and self.saved:
                         logging.warning('calling download from %s to %s', self.s3_path + f, filepath)
                         download(self.s3_conn, filepath, os.path.join(self.s3_path, f))
-                model = Doc2Vec.load('tmp/' + self.model_name)
+                model = Doc2Vec.load(os.path.join(LOCAL_CACHE_DIRECTORY, self.model_name))
 
             return model
 
@@ -96,7 +97,7 @@ class VectorModel(object):
             dict: a lookup table for mapping gensim index to soc code.
         """
         try:
-            filepath = 'tmp/' + self.lookup_name
+            filepath = os.path.join(LOCAL_CACHE_DIRECTORY, self.lookup_name)
             with open(filepath, 'r') as handle:
                 lookup = json.load(handle)
             return lookup
@@ -112,7 +113,7 @@ class VectorModel(object):
                         lookup = json.load(handle)
 
             else:
-                filepath = 'tmp/' + self.lookup_name
+                filepath = os.path.join(LOCAL_CACHE_DIRECTORY, self.lookup_name)
                 if not os.path.exists(filepath):
                     logging.warning('calling download from %s to %s', self.s3_path + self.lookup_name, filepath)
                     download(self.s3_conn, filepath , os.join(self.s3_path, self.lookup_name))

--- a/skills_ml/algorithms/occupation_classifiers/base.py
+++ b/skills_ml/algorithms/occupation_classifiers/base.py
@@ -48,7 +48,6 @@ class VectorModel(object):
         self.lookup_name = 'lookup_' + self.model_id + '.json'
         self.s3_path = s3_path + self.model_id
         self.s3_conn = s3_conn
-        self.files  = list_files(self.s3_conn, self.s3_path)
         self.model = self._load_model() if model == None else model
         self.lookup = self._load_lookup() if lookup == None else lookup
         self.training_data = self.model.docvecs.doctag_syn0
@@ -63,26 +62,32 @@ class VectorModel(object):
         Returns:
             gensim.models.doc2vec.Doc2Vec: The word-embedding model object.
         """
-        if not self.saved:
-            with tempfile.TemporaryDirectory() as td:
-                for f in self.files:
-                    filepath = os.path.join(td, f)
-                    if not os.path.exists(filepath):
+        try:
+            model = Doc2Vec.load('tmp/' + self.model_name)
+            return model
+
+        except:
+            files  = list_files(self.s3_conn, self.s3_path)
+            if not self.saved:
+                with tempfile.TemporaryDirectory() as td:
+                    for f in files:
+                        filepath = os.path.join(td, f)
+                        if not os.path.exists(filepath):
+                            logging.warning('calling download from %s to %s', self.s3_path + f, filepath)
+                            download(self.s3_conn, filepath, os.path.join(self.s3_path, f))
+                    model = Doc2Vec.load(os.path.join(td, self.model_name))
+
+            else:
+                if not os.path.isdir('tmp'):
+                    os.mkdir('tmp')
+                for f in files:
+                    filepath = 'tmp/' + f
+                    if not os.path.exists(filepath) and self.saved:
                         logging.warning('calling download from %s to %s', self.s3_path + f, filepath)
                         download(self.s3_conn, filepath, os.path.join(self.s3_path, f))
-                model = Doc2Vec.load(os.path.join(td, self.model_name))
+                model = Doc2Vec.load('tmp/' + self.model_name)
 
-        else:
-            if not os.path.isdir('tmp'):
-                os.mkdir('tmp')
-            for f in self.files:
-                filepath = 'tmp/' + f
-                if not os.path.exists(filepath) and self.saved:
-                    logging.warning('calling download from %s to %s', self.s3_path + f, filepath)
-                    download(self.s3_conn, filepath, os.path.join(self.s3_path, f))
-            model = Doc2Vec.load('tmp/' + self.model_name)
-
-        return model
+            return model
 
     def _load_lookup(self):
         """The method to download the lookup dictionary from S3 and load to the memory.
@@ -90,24 +95,31 @@ class VectorModel(object):
         Returns:
             dict: a lookup table for mapping gensim index to soc code.
         """
-        if not self.saved:
-            with tempfile.TemporaryDirectory() as td:
-                filepath = os.path.join(td, self.lookup_name)
-                print(filepath)
-                logging.warning('calling download from %s to %s', self.s3_path + self.lookup_name, filepath)
-                download(self.s3_conn, filepath, os.path.join(self.s3_path, self.lookup_name))
+        try:
+            filepath = 'tmp/' + self.lookup_name
+            with open(filepath, 'r') as handle:
+                lookup = json.load(handle)
+            return lookup
+        except:
+
+            if not self.saved:
+                with tempfile.TemporaryDirectory() as td:
+                    filepath = os.path.join(td, self.lookup_name)
+                    print(filepath)
+                    logging.warning('calling download from %s to %s', self.s3_path + self.lookup_name, filepath)
+                    download(self.s3_conn, filepath, os.path.join(self.s3_path, self.lookup_name))
+                    with open(filepath, 'r') as handle:
+                        lookup = json.load(handle)
+
+            else:
+                filepath = 'tmp/' + self.lookup_name
+                if not os.path.exists(filepath):
+                    logging.warning('calling download from %s to %s', self.s3_path + self.lookup_name, filepath)
+                    download(self.s3_conn, filepath , os.join(self.s3_path, self.lookup_name))
                 with open(filepath, 'r') as handle:
                     lookup = json.load(handle)
 
-        else:
-            filepath = 'tmp/' + self.lookup_name
-            if not os.path.exists(filepath):
-                logging.warning('calling download from %s to %s', self.s3_path + self.lookup_name, filepath)
-                download(self.s3_conn, filepath , os.join(self.s3_path, self.lookup_name))
-            with open(filepath, 'r') as handle:
-                lookup = json.load(handle)
-
-        return lookup
+            return lookup
 
     def _create_target_data(self):
         """To create a label array by mapping each doc vector to the lookup table.

--- a/skills_ml/algorithms/occupation_classifiers/train.py
+++ b/skills_ml/algorithms/occupation_classifiers/train.py
@@ -1,0 +1,40 @@
+from gensim.models.doc2vec import Doc2Vec
+
+from skills_ml.datasets import job_postings
+from skills_ml.algorithms.corpus_creators.basic import Doc2VecGensimCorpusCreator
+
+from skills_utils.s3 import upload
+
+from datetime import datetime
+from itertools import chain
+from glob import glob
+
+import json
+import logging
+logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)
+
+def train_representation(s3_conn, quarters, jb_s3_path):
+    generators = []
+    for quarter in quarters:
+        generators.append(job_postings(s3_conn, quarter, jb_s3_path))
+    job_postings_generator = chain(*generators)
+    corpus = Doc2VecGensimCorpusCreator(list(job_postings_generator))
+    corpus_list = list(corpus)
+    model = Doc2Vec(size=500, min_count=3, iter=10, window=6, workers=2)
+    model.build_vocab(corpus_list)
+    model.train(corpus_list, total_examples=model.corpus_count, epochs=model.iter)
+
+    training_time = datetime.today().isoformat()
+    modelname = 'doc2vec_' + training_time
+    model_path = 'tmp/' + modelname + '.model'
+    model.save(model_path)
+
+    lookupname = 'doc2vec_lookup_' + training_time
+    lookup_path = 'tmp/' + lookupname + '.json'
+    with open(lookup_path, 'w') as handle:
+        json.dump(corpus.lookup, handle)
+
+    for f in glob('tmp/*{}*'.format(training_time)):
+        upload(s3_conn, f, 'open-skills-private/model_cache/' + modelname)
+
+

--- a/skills_ml/algorithms/occupation_classifiers/train.py
+++ b/skills_ml/algorithms/occupation_classifiers/train.py
@@ -58,7 +58,7 @@ class RepresentationTrainer(object):
         job_postings_generator = chain(*generators)
         corpus = Doc2VecGensimCorpusCreator(list(job_postings_generator))
         corpus_list = list(corpus)
-        model = Doc2Vec(size=500, min_count=3, iter=5, window=6, workers=2, **kwargs)
+        model = Doc2Vec(size=size, min_count=min_count, iter=iter, window=window, workers=workers, **kwargs)
         model.build_vocab(corpus_list)
         model.train(corpus_list, total_examples=model.corpus_count, epochs=model.iter)
         self.model = model

--- a/skills_ml/algorithms/occupation_classifiers/train.py
+++ b/skills_ml/algorithms/occupation_classifiers/train.py
@@ -1,4 +1,6 @@
 from gensim.models.doc2vec import Doc2Vec
+from gensim import __version__ as gensim_version
+from gensim import __name__ as gensim_name
 
 from skills_ml.datasets import job_postings
 from skills_ml.algorithms.corpus_creators.basic import Doc2VecGensimCorpusCreator
@@ -13,28 +15,95 @@ import json
 import logging
 logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)
 
-def train_representation(s3_conn, quarters, jb_s3_path):
-    generators = []
-    for quarter in quarters:
-        generators.append(job_postings(s3_conn, quarter, jb_s3_path))
-    job_postings_generator = chain(*generators)
-    corpus = Doc2VecGensimCorpusCreator(list(job_postings_generator))
-    corpus_list = list(corpus)
-    model = Doc2Vec(size=500, min_count=3, iter=10, window=6, workers=2)
-    model.build_vocab(corpus_list)
-    model.train(corpus_list, total_examples=model.corpus_count, epochs=model.iter)
+class RepresentationTrainer(object):
+    """A representation learning object using gensim doc2vec model.
+    Example:
 
-    training_time = datetime.today().isoformat()
-    modelname = 'doc2vec_' + training_time
-    model_path = 'tmp/' + modelname + '.model'
-    model.save(model_path)
+    from airflow.hooks import S3Hook
+    from skills_ml.algorithms.occupation_classifiers.train import RepresentationTrainer
 
-    lookupname = 'doc2vec_lookup_' + training_time
-    lookup_path = 'tmp/' + lookupname + '.json'
-    with open(lookup_path, 'w') as handle:
-        json.dump(corpus.lookup, handle)
+    s3_conn = S3Hook().get_conn()
+    trainer = RepresentationTrainer(s3_conn, ['2011Q1', '2011Q2'], 'open-skills-private/test_corpus')
+    trainer.train()
+    """
+    def __init__(self, s3_conn, quarters, jb_s3_path):
+        """Initialization
 
-    for f in glob('tmp/*{}*'.format(training_time)):
-        upload(s3_conn, f, 'open-skills-private/model_cache/' + modelname)
+        Attributes:
+            s3_conn (:obj: `boto.s3.connection.S3Connection`): the boto object to connect to S3.
+            quarters (:obj: `list` of (str)): quarters will be trained on
+            jb_s3_path (:str): job posting path on S3
+            model (:obj: `gensim.models.doc2vec.Doc2Vec`): gensim doc2vec model object
+            metadata (:dict): model metadata
+            training_time (:str): training time
+        """
+        self.s3_conn = s3_conn
+        self.quarters = quarters
+        self.jb_s3_path = jb_s3_path
+        self.model = None
+        self._metadata = None
+        self.training_time = datetime.today().isoformat()
 
+    def train(self, size=500, min_count=3, iter=8, window=6, workers=2, **kwargs):
+        """Train a doc2vec model, build a lookup table and model metadata. After training, they will be saved to S3.
 
+        Args:
+            kwargs: all arguments that gensim.models.doc2vec.Docvec will take.
+        """
+        generators = []
+        for quarter in self.quarters:
+            generators.append(job_postings(self.s3_conn, quarter, self.jb_s3_path))
+        job_postings_generator = chain(*generators)
+        corpus = Doc2VecGensimCorpusCreator(list(job_postings_generator))
+        corpus_list = list(corpus)
+        model = Doc2Vec(size=500, min_count=3, iter=5, window=6, workers=2, **kwargs)
+        model.build_vocab(corpus_list)
+        model.train(corpus_list, total_examples=model.corpus_count, epochs=model.iter)
+        self.model = model
+
+        modelname = 'doc2vec_' + self.training_time
+        model_path = 'tmp/' + modelname + '.model'
+        model.save(model_path)
+
+        lookupname = 'lookup_' + self.training_time
+        lookup_path = 'tmp/' + lookupname + '.json'
+        with open(lookup_path, 'w') as handle:
+            json.dump(corpus.lookup, handle)
+
+        if self.model:
+            meta_dict = {}
+            meta_dict['metadata'] = {}
+            meta_dict['metadata']['hyperparameters'] = {
+                                            'vector_size': self.model.vector_size,
+                                            'window': self.model.window,
+                                            'min_count': self.model.min_count,
+                                            'workers': self.model.workers,
+                                            'sample': self.model.sample,
+                                            'alpha': self.model.alpha,
+                                            'seed': self.model.seed,
+                                            'iter': self.model.iter,
+                                            'hs': self.model.hs,
+                                            'negative': self.model.negative,
+                                            'dm_mean': self.model.dm_mean if 'dm_mean' in self.model else None,
+                                            'cbow_mean': self.model.cbow_mean if 'cbow_mean' in self.model else None,
+                                            'dm': self.model.dm,
+                                            'dbow_words': self.model.dbow_words,
+                                            'dm_concat': self.model.dm_concat,
+                                            'dm_tag_count': self.model.dm_tag_count
+                                            }
+            meta_dict['metadata']['quarters'] = self.quarters
+            meta_dict['metadata']['model_name'] = 'doc2vec' + self.training_time
+            meta_dict['metadata']['gensim_version']  = gensim_name + gensim_version
+
+            self._metadata = meta_dict
+            metaname = 'metadata_' + self.training_time
+            meta_path = 'tmp/' + metaname + '.json'
+            with open(meta_path, 'w') as handle:
+                json.dump(meta_dict, handle, indent=4, separators=(',', ': '))
+
+        for f in glob('tmp/*{}*'.format(self.training_time)):
+            upload(self.s3_conn, f, 'open-skills-private/model_cache/' + modelname)
+
+    @property
+    def metadata(self):
+        return self._metadata

--- a/tests/test_corpus_base.py
+++ b/tests/test_corpus_base.py
@@ -13,5 +13,5 @@ def test_raw_corpora():
     assert next(ExampleCorpusCreator().raw_corpora(sample_input)) == 'We are looking for a person to fill this job'
 
 def test_array_corpora():
-    assert next(ExampleCorpusCreator().array_corpora(sample_input)) == \
+    assert next(ExampleCorpusCreator().tokenize_corpora(sample_input)) == \
         ['We', 'are', 'looking', 'for', 'a', 'person', 'to', 'fill', 'this', 'job']

--- a/tests/test_corpus_word2vec_creator.py
+++ b/tests/test_corpus_word2vec_creator.py
@@ -1,5 +1,5 @@
-from skills_ml.algorithms.corpus_creators.basic import Doc2VecGensimCorpusCreator
-def test_doc2vec_corpus_creator():
+from skills_ml.algorithms.corpus_creators.basic import Word2VecGensimCorpusCreator
+def test_word2vec_corpus_creator():
     sample_document = {
         "incentiveCompensation": "",
         "experienceRequirements": "Here are some experience and requirements",
@@ -32,5 +32,5 @@ def test_doc2vec_corpus_creator():
         "@type": "JobPosting"
     }
 
-    corpus = Doc2VecGensimCorpusCreator()._transform(sample_document)
+    corpus = Word2VecGensimCorpusCreator()._transform(sample_document)
     assert corpus == 'we are looking for a person to fill this job here are some experience and requirements here are some qualifications customer service consultant entry level'

--- a/tests/test_train_occupation_classifiers.py
+++ b/tests/test_train_occupation_classifiers.py
@@ -1,0 +1,68 @@
+from skills_ml.algorithms.occupation_classifiers.train import RepresentationTrainer
+
+from skills_utils.s3 import upload, list_files, download
+
+from moto import mock_s3
+import tempfile
+import boto
+import os
+import json
+
+sample_document = {
+    "incentiveCompensation": "",
+    "experienceRequirements": "Here are some experience and requirements",
+    "baseSalary": {
+        "maxValue": 0.0,
+        "@type": "MonetaryAmount",
+        "minValue": 0.0
+    },
+    "description": "We are looking for a person to fill this job",
+    "title": "Bilingual (Italian) Customer Service Rep (Work from Home)",
+    "employmentType": "Full-Time",
+    "industry": "Call Center / SSO / BPO, Consulting, Sales - Marketing",
+    "occupationalCategory": "",
+    "onet_soc_code": "41-1011.00",
+    "qualifications": "Here are some qualifications",
+    "educationRequirements": "Not Specified",
+    "skills": "Customer Service, Consultant, Entry Level",
+    "validThrough": "2014-01-02T00:00:00",
+    "jobLocation": {
+        "@type": "Place",
+        "address": {
+            "addressLocality": "Salisbury",
+            "addressRegion": "PA",
+            "@type": "PostalAddress"
+        }
+    },
+    "@context": "http://schema.org",
+    "alternateName": "Customer Service Representative",
+    "datePosted": "2013-05-12",
+    "@type": "JobPosting"
+}
+
+@mock_s3
+def test_representation_trainer():
+    s3_conn = boto.connect_s3()
+    bucket_name = 'fake-jb-bucket'
+    bucket = s3_conn.create_bucket(bucket_name)
+
+    job_posting_name = 'FAKE_jobposting'
+    s3_prefix_jb = 'fake-jb-bucket/job_postings'
+    s3_prefix_model = 'fake-jb-bucket/model_cache'
+    quarters = '2011Q1'
+
+    with tempfile.TemporaryDirectory() as td:
+        with open(os.path.join(td, job_posting_name), 'w') as handle:
+            json.dump(sample_document, handle)
+        upload(s3_conn, os.path.join(td, job_posting_name), os.path.join(s3_prefix_jb, quarters))
+
+
+    trainer = RepresentationTrainer(s3_conn, ['2011Q1'], s3_prefix_jb, s3_prefix_model)
+    trainer.train()
+    files = list_files(s3_conn, s3_prefix_model)
+    assert len(files) == 3
+
+
+    assert files == ['doc2vec_' + trainer.training_time + '.model',
+                     'lookup_' + trainer.training_time + '.json',
+                     'metadata_' + trainer.training_time + '.json']


### PR DESCRIPTION
Implemented the training part of doc2vec which will take a list of quarters and train a gensim doc2vec model. It will save the model, lookup table and model metadata to S3.

- Change some corpus creators to match doc2vec and word2vec
- Be able to load models from local tmp directory if they exist
- Added a `RepresentationTrainer` class in `algorithms.occupation_classifiers.train`
- Added/modified several tests for corpus creators and train_occupation_classifiers