### PR TITLE
Occupation-scoped skill extraction [Resolves #95]

### DIFF
--- a/skills_ml/algorithms/aggregators/__init__.py
+++ b/skills_ml/algorithms/aggregators/__init__.py
@@ -99,6 +99,22 @@ class SkillAggregator(JobAggregator):
         )
 
 
+class OccupationScopedSkillAggregator(SkillAggregator):
+    """Aggregates skills found in job postings using the job's occupation
+
+    Args:
+        skill_extractor (.skill_extractors.FreetextSkillExtractor)
+            an object that returns skill counts from unstructured text
+        corpus creator (object) an object that returns a text corpus
+            from a job posting
+    """
+    def value(self, job_posting):
+        return self.skill_extractor.document_skill_counts(
+            soc_code=job_posting.get('onet_soc_code', None),
+            document=self.corpus_creator._transform(job_posting)
+        )
+
+
 class SocCodeAggregator(JobAggregator):
     """Aggregates SOC codes inferred from job posting text
 

--- a/skills_ml/algorithms/occupation_classifiers/classifiers.py
+++ b/skills_ml/algorithms/occupation_classifiers/classifiers.py
@@ -11,7 +11,7 @@ from skills_utils.s3 import download, split_s3_path, list_files
 
 
 def download_ann_classifier_files(s3_prefix, classifier_id, download_directory, s3_conn):
-    lock = filelock.Filelock(os.path.join(download_directory, 'ann_dl.lock'))
+    lock = filelock.FileLock(os.path.join(download_directory, 'ann_dl.lock'))
     with lock.acquire(timeout=1000):
         s3_path = s3_prefix + classifier_id
         files = list_files(s3_conn, s3_path)

--- a/skills_ml/algorithms/skill_extractors/freetext.py
+++ b/skills_ml/algorithms/skill_extractors/freetext.py
@@ -116,35 +116,3 @@ class OccupationScopedSkillExtractor(FreetextSkillExtractor):
             All values set to 1 (multiple occurrences of a skill do not count)
         """
         return self._document_skills_in_lookup(document, self.lookup[soc_code])
-
-
-class FakeFreetextSkillExtractor(FreetextSkillExtractor):
-    """A skill extractor that takes a list of skills
-    instead of reading from a filename
-    """
-    def __init__(self, skills):
-        """
-        Args:
-            skills (list) skill names that the extractor should use
-        """
-        self.skills = skills
-        super(FakeFreetextSkillExtractor, self).__init__('')
-
-    def _skills_lookup(self):
-        return set(self.skills)
-
-
-class FakeOccupationScopedSkillExtractor(OccupationScopedSkillExtractor):
-    """A skill extractor that takes a list of skills
-    instead of reading from a filename
-    """
-    def __init__(self, skills):
-        """
-        Args:
-            skills (dict) soc codes as keys, lists of skill names as values
-        """
-        self.skills = skills
-        super(FakeOccupationScopedSkillExtractor, self).__init__('')
-
-    def _skills_lookup(self):
-        return self.skills

--- a/skills_ml/algorithms/skill_extractors/freetext.py
+++ b/skills_ml/algorithms/skill_extractors/freetext.py
@@ -1,6 +1,6 @@
 import csv
 import logging
-from collections import Counter
+from collections import Counter, defaultdict
 
 from skills_ml.algorithms.string_cleaners import NLPTransforms
 
@@ -38,14 +38,15 @@ class FreetextSkillExtractor(object):
             generator = (row[index] for row in reader)
             return set(generator)
 
-    def document_skill_counts(self, document):
+    def _document_skills_in_lookup(self, document, lookup):
         """Count skills in the document
 
         Args:
+            lookup (object) A collection that can be queried for an individual skill, implementing 'in' (i.e. 'skill in lookup')
             document (string) A document for searching, such as a job posting
 
-        Returns: (collections.Counter) skills found in the document, all
-            values set to 1 (multiple occurrences of a skill do not count)
+        Returns: (collections.Counter) skills present in the lookup found in the document
+            All values set to 1 (multiple occurrences of a skill do not count)
         """
         join_spaces = " ".join  # for runtime efficiency
         N = 5
@@ -61,13 +62,60 @@ class FreetextSkillExtractor(object):
             lookahead = min(N, doc_len - start_idx)
             for idx in range(lookahead, 0, -1):
                 ngram = join_spaces(doc[start_idx:start_idx+idx])
-                if ngram in self.lookup:
+                if ngram in lookup:
                     skills[ngram] = 1
                     offset = idx
                     break
 
             start_idx += offset
         return skills
+
+    def document_skill_counts(self, document):
+        """Count skills in the document
+
+        Args:
+            document (string) A document for searching, such as a job posting
+
+        Returns: (collections.Counter) skills found in the document, all
+            values set to 1 (multiple occurrences of a skill do not count)
+        """
+        return self._document_skills_in_lookup(document, self.lookup)
+
+
+class OccupationScopedSkillExtractor(FreetextSkillExtractor):
+    """Extract skills from unstructured text,
+    but only return matches that agree with a known taxonomy
+    """
+    def _skills_lookup(self):
+        """Create skills lookup
+
+        Reads the object's filename containing skills into a lookup
+
+        Returns: (set) skill names
+        """
+        logging.info('Creating skills lookup from %s', self.skills_filename)
+        lookup = defaultdict(set)
+        with open(self.skills_filename) as infile:
+            reader = csv.reader(infile, delimiter='\t')
+            header = next(reader)
+            ksa_index = header.index(self.nlp.transforms[0])
+            soc_index = header.index('O*NET-SOC Code')
+            for row in reader:
+                lookup[row[soc_index]].add(row[ksa_index])
+            return lookup
+
+    def document_skill_counts(self, soc_code, document):
+        """Count skills in the document
+
+        Args:
+            soc_code (string) A trusted SOC code for the job posting
+            document (string) A document for searching, such as a job posting
+
+        Returns: (collections.Counter) skills found in the document, that match
+            a known set of skills for the SOC code.
+            All values set to 1 (multiple occurrences of a skill do not count)
+        """
+        return self._document_skills_in_lookup(document, self.lookup[soc_code])
 
 
 class FakeFreetextSkillExtractor(FreetextSkillExtractor):
@@ -84,3 +132,19 @@ class FakeFreetextSkillExtractor(FreetextSkillExtractor):
 
     def _skills_lookup(self):
         return set(self.skills)
+
+
+class FakeOccupationScopedSkillExtractor(OccupationScopedSkillExtractor):
+    """A skill extractor that takes a list of skills
+    instead of reading from a filename
+    """
+    def __init__(self, skills):
+        """
+        Args:
+            skills (dict) soc codes as keys, lists of skill names as values
+        """
+        self.skills = skills
+        super(FakeOccupationScopedSkillExtractor, self).__init__('')
+
+    def _skills_lookup(self):
+        return self.skills

--- a/tests/test_title_aggregators.py
+++ b/tests/test_title_aggregators.py
@@ -16,8 +16,40 @@ from skills_ml.algorithms.aggregators import \
 from skills_ml.algorithms.aggregators.title import GeoTitleAggregator
 from skills_ml.algorithms.string_cleaners import NLPTransforms
 from skills_ml.algorithms.skill_extractors.freetext import \
-    FakeFreetextSkillExtractor, FakeOccupationScopedSkillExtractor
+    FreetextSkillExtractor, OccupationScopedSkillExtractor
 from skills_ml.algorithms.corpus_creators.basic import SimpleCorpusCreator
+
+
+class FakeFreetextSkillExtractor(FreetextSkillExtractor):
+    """A skill extractor that takes a list of skills
+    instead of reading from a filename
+    """
+    def __init__(self, skills):
+        """
+        Args:
+            skills (list) skill names that the extractor should use
+        """
+        self.skills = skills
+        super().__init__('')
+
+    def _skills_lookup(self):
+        return set(self.skills)
+
+
+class FakeOccupationScopedSkillExtractor(OccupationScopedSkillExtractor):
+    """A skill extractor that takes a list of skills
+    instead of reading from a filename
+    """
+    def __init__(self, skills):
+        """
+        Args:
+            skills (dict) soc codes as keys, lists of skill names as values
+        """
+        self.skills = skills
+        super().__init__('')
+
+    def _skills_lookup(self):
+        return self.skills
 
 
 class FakeCBSAQuerier(object):

--- a/tests/test_title_aggregators.py
+++ b/tests/test_title_aggregators.py
@@ -9,13 +9,14 @@ from skills_utils.iteration import Batch
 
 from skills_ml.algorithms.aggregators import \
     SkillAggregator,\
+    OccupationScopedSkillAggregator,\
     CountAggregator,\
     SocCodeAggregator,\
     GivenSocCodeAggregator
 from skills_ml.algorithms.aggregators.title import GeoTitleAggregator
 from skills_ml.algorithms.string_cleaners import NLPTransforms
 from skills_ml.algorithms.skill_extractors.freetext import \
-    FakeFreetextSkillExtractor
+    FakeFreetextSkillExtractor, FakeOccupationScopedSkillExtractor
 from skills_ml.algorithms.corpus_creators.basic import SimpleCorpusCreator
 
 
@@ -32,31 +33,38 @@ SAMPLE_JOBS = [
     {
         'id': 1,
         'title': 'Cupcake Ninja',
-        'description': 'Slicing and dicing frosting'
+        'description': 'Slicing and dicing frosting',
+        'onet_soc_code': '23-1234.00',
     },
     {
         'id': 2,
         'title': 'Regular Ninja',
-        'description': 'Slicing and dicing enemies'
+        'description': 'Slicing and dicing enemies',
+        'onet_soc_code': '12-1234.00',
     },
     {
         'id': 3,
         'title': 'React Ninja',
-        'description': 'Slicing and dicing components'
+        'description': 'Slicing and dicing components',
+        'onet_soc_code': '12-1234.00',
     },
     {
         'id': 4,
         'title': 'React Ninja',
-        'description': 'Slicing and dicing and then trashing jQuery'
+        'description': 'Slicing and dicing and then trashing jQuery',
+        'onet_soc_code': '12-1234.00',
     },
 ]
 
 
 def build_basic_geo_title_aggregator():
     job_aggregators = OrderedDict(
-        skills=SkillAggregator(
-            skill_extractor=FakeFreetextSkillExtractor(
-                skills=['slicing', 'dicing', 'jquery']
+        skills=OccupationScopedSkillAggregator(
+            skill_extractor=FakeOccupationScopedSkillExtractor(
+                skills={
+                    '12-1234.00': ['slicing', 'dicing', 'jquery'],
+                    '23-1234.00': ['slicing', 'dicing', 'jquery'],
+                }
             ),
             corpus_creator=SimpleCorpusCreator(),
             output_count=2
@@ -322,13 +330,4 @@ def test_soc_aggregator():
 def test_given_soc_aggregator():
     aggregator = GivenSocCodeAggregator()
     aggregate = sum(map(aggregator.value, SAMPLE_JOBS), Counter())
-    assert aggregate == {'99-9999.00': len(SAMPLE_JOBS)}
-
-    weighted_jobs = copy.deepcopy(SAMPLE_JOBS)
-    for job in weighted_jobs:
-        if job['id'] == 1:
-            job['onet_soc_code'] = '23-1234.00'
-        else:
-            job['onet_soc_code'] = '12-1234.00'
-    aggregate = sum(map(aggregator.value, weighted_jobs), Counter())
     assert aggregate == {'23-1234.00': 1, '12-1234.00': 3}


### PR DESCRIPTION
- Add OccupationScopedSkillExtractor to create and use an occupation-scoped skill lookup instead of all ONET skills when extracting skills from postings
- Add OccupationScopedSkillAggregator that complies with the expanded interface needed by OccupationScopedSkillExtractor
- Fix usage of FileLock