### PR TITLE
Geocode both with state name and code [Resolves #100]

### DIFF
--- a/skills_ml/algorithms/geocoders/__init__.py
+++ b/skills_ml/algorithms/geocoders/__init__.py
@@ -24,7 +24,7 @@ def job_posting_search_strings(job_posting):
     """
     location = json.loads(job_posting).get('jobLocation', None)
     if not location:
-        return None
+        return []
     locality = location.get('address', {}).get('addressLocality', None)
     region = location.get('address', {}).get('addressRegion', None)
     if locality and region:

--- a/tests/test_geocoders.py
+++ b/tests/test_geocoders.py
@@ -1,5 +1,5 @@
 from skills_ml.algorithms.geocoders import S3CachedGeocoder,\
-    job_posting_search_string
+    job_posting_search_strings
 from skills_ml.algorithms.geocoders.cbsa import S3CachedCBSAFinder
 import json
 from unittest.mock import MagicMock, call, patch
@@ -78,11 +78,11 @@ def test_geocode_job_postings():
         == sample_geocode_result
 
 
-def test_job_posting_search_string():
+def test_job_posting_search_strings():
     with open('sample_job_listing.json') as f:
         sample_job_posting = f.read()
 
-    assert job_posting_search_string(sample_job_posting) == 'Salisbury, Pennsylvania'
+    assert sorted(job_posting_search_strings(sample_job_posting)) == sorted(['Salisbury, Pennsylvania', 'Salisbury, PA'])
 
 
 def test_job_posting_weird_region():
@@ -91,13 +91,13 @@ def test_job_posting_weird_region():
         'addressRegion': 'Northeastern USA'
     }}}
 
-    assert job_posting_search_string(json.dumps(fake_job)) ==\
-        'Any City, Northeastern USA'
+    assert job_posting_search_strings(json.dumps(fake_job)) ==\
+        ['Any City, Northeastern USA']
 
 
 def test_job_posting_search_string_only_city():
     fake_job = {'jobLocation': {'address': {'addressLocality': 'City'}}}
-    assert job_posting_search_string(json.dumps(fake_job)) == 'City'
+    assert job_posting_search_strings(json.dumps(fake_job)) == ['City']
 
 
 @moto.mock_s3

--- a/tests/test_geocoders.py
+++ b/tests/test_geocoders.py
@@ -100,6 +100,15 @@ def test_job_posting_search_string_only_city():
     assert job_posting_search_strings(json.dumps(fake_job)) == ['City']
 
 
+def test_job_posting_search_string_bad_address():
+    fake_job = {'jobLocation': {'address': {}}}
+    assert job_posting_search_strings(json.dumps(fake_job)) == []
+
+
+def test_job_posting_search_string_no_location():
+    assert job_posting_search_strings('{}') == []
+
+
 @moto.mock_s3
 def test_cbsa_finder_onehit():
     s3_conn = boto.connect_s3()

--- a/tests/test_job_geo_queriers.py
+++ b/tests/test_job_geo_queriers.py
@@ -136,8 +136,12 @@ class CBSATest(unittest.TestCase):
 
 
 cbsa_results = {
+    # have the IL results differ to make sure that we catch the one with a CBSA
     'Elgin, Illinois': ['456', 'Chicago, IL Metro Area'],
+    'Elgin, IL': None,
+    # TX results should consistently be None so we can test searches that are outside any CBSA
     'Elgin, Texas': None,
+    'Elgin, TX': None,
 }
 
 


### PR DESCRIPTION
- Change job_posting_search_string to job_posting_search_strings and return both the city/state and city/statecode versions
- Geocode and cache all job_posting_search_strings for a job posting
- When finding CBSAs, pick the first job_posting_search_string that matches any CBSA
- Show full traceback when quitting geocoding to help debugging
- When loading geocoder, explicitly handle None case and convert to empty dict