### PR TITLE
BRAT Experiment [Resolves #136]

### DIFF
--- a/docs/pydocmd.yml
+++ b/docs/pydocmd.yml
@@ -20,8 +20,8 @@ generate:
     skills_ml.datasets.partner_updaters.usa_jobs+, skills_ml.datasets.place_ua+, skills_ml.datasets.sba_city_county+,
     skills_ml.datasets.skill_importances+, skills_ml.datasets.skill_importances.onet+,
     skills_ml.datasets.skills+, skills_ml.datasets.skills.onet_ksat+, skills_ml.datasets.ua_cbsa+]
-- skills_ml.evaluation.md: [skills_ml.evaluation.job_title_normalizers+, skills_ml.evaluation.representativeness_calculators+,
-    skills_ml.evaluation.representativeness_calculators.geo_occupation+]
+- skills_ml.evaluation.md: [skills_ml.evaluation.annotators+, skills_ml.evaluation.job_title_normalizers+,
+    skills_ml.evaluation.representativeness_calculators+, skills_ml.evaluation.representativeness_calculators.geo_occupation+]
 - skills_ml.job_postings.md: [skills_ml.job_postings.aggregate+, skills_ml.job_postings.aggregate.dataset_transform+,
     skills_ml.job_postings.aggregate.field_values+, skills_ml.job_postings.aggregate.geo+,
     skills_ml.job_postings.aggregate.pandas+, skills_ml.job_postings.aggregate.soc_code+,

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ fuzzywuzzy==0.16.0
 python-Levenshtein==0.12.0
 dickens==1.0.1
 skills-utils==0.4.0
+s3fs==0.1.4

--- a/skills_ml/evaluation/annotators.py
+++ b/skills_ml/evaluation/annotators.py
@@ -415,6 +415,7 @@ class BratExperiment(object):
                 job_posting_id = posting_id_lookup[int(posting_key)]
                 for annotation in posting_annotations:
                     annotation['job_posting_id'] = job_posting_id
+                    annotation['sample_name'] = self.metadata['sample_name']
                     flattened_labels.append(annotation)
         # take labels with agreement by unit
         # flatten, taking unit/posting key and looking up job posting id to include in dict

--- a/skills_ml/evaluation/annotators.py
+++ b/skills_ml/evaluation/annotators.py
@@ -1,0 +1,421 @@
+from copy import deepcopy
+import logging
+import unicodecsv as csv
+from statistics import mean
+
+import s3fs
+from descriptors import cachedproperty
+
+from skills_utils.iteration import Batch
+from skills_utils.s3 import S3BackedJsonDict
+from skills_ml.job_postings import JobPosting
+
+
+class BratExperiment(object):
+    """Manage a BRAT experiment. Handles:
+
+    1. The creation of BRAT config for a specific sample of job postings
+    2. Adding users to the installation and allocating them semi-hidden job postings
+    3. The parsing of the annotation results at the end of the experiment
+
+    Syncs data to an experiment directory on S3.
+    BRAT installations are expected to sync this data down regularly.
+
+    Keeps track of a metadata file,
+    available as a dictionary at self.metadata, with the following structure:
+
+    # these first five keys are just storage of user input to either
+    # the constructor or start()
+    # view relevant docstrings for definitions
+    sample_base_path
+    sample_name
+    entities_with_shortcuts
+    minimum_annotations_per_posting
+    max_postings_per_allocation
+
+    # units and allocations are far more important when reading results of an experiment
+    units: {
+        # canonical list of 'unit' (bundle of job postings) names,
+        # along with a list of tuples of job posting keys (only unique within unit)
+            and globally unique job posting ids
+        'unit_1': [
+            (posting_key_1, job_posting_id_1),
+            (posting_key_2, job_posting_id_2),
+        ],
+        'unit_2': [
+            (posting_key_1, job_posting_id_3),
+            (posting_key_2, job_posting_id_4),
+        ]
+    }
+    allocations: {
+        # canonical list of unit assignments to users
+        'user_1': ['unit_1', 'unit_2'],
+        'user_2': ['unit_2']
+    }
+    """
+    def __init__(self, experiment_name, brat_s3_path):
+        self.experiment_name = experiment_name
+        self.brat_s3_path = brat_s3_path
+        self.metadata = S3BackedJsonDict(
+            path=self.experiment_path + '/metadata'
+        )
+        self.user_pw_store = S3BackedJsonDict(
+            path=self.experiment_path + '/user-pws'
+        )
+        self.s3 = s3fs.S3FileSystem()
+
+    @property
+    def experiment_path(self):
+        "The s3 path to all files relating to the experiment"
+        return '/'.join([self.brat_s3_path, self.experiment_name])
+
+    @property
+    def brat_config_path(self):
+        "The s3 path to BRAT config files for the experiment"
+        return '/'.join([self.experiment_path, 'brat_config'])
+
+    @property
+    def data_path(self):
+        "The s3 path to job postings for the experiment"
+        return '/'.join([self.brat_config_path, 'data'])
+
+    def unit_path(self, unit_name):
+        "The s3 path to job postings for a particular unit"
+        return '/'.join([self.data_path, '.' + unit_name])
+
+    def user_allocations_path(self, user_name):
+        "The s3 path to all allocations for a user (i.e what they should see when logging in"
+        return '/'.join([self.data_path, '.' + user_name])
+
+    def allocation_path(self, user_name, unit_name):
+        "The s3 path for a particular allocation for a user"
+        return '/'.join([self.user_allocations_path(user_name), unit_name])
+
+    def start(
+        self,
+        sample,
+        entities_with_shortcuts,
+        minimum_annotations_per_posting=2,
+        max_postings_per_allocation=10,
+    ):
+        """Starts a BRAT experiment by dividing up a job posting sample into units
+            and creating BRAT config files
+
+        Args:
+            sample (skills_ml.algorithms.sampling.Sample) A sample of job postings
+            entities_with_shortcuts (collection of tuples) The distinct entities to tag.
+                The first entry of each tuple should be a one character string
+                    that can be used as a keyboard shortcut in BRAT
+                The second entry of each tuple should be the name of the entity
+                    that shows up in menus
+            minimum_annotations_per_posting (int, optional) How many people should annotate
+                each job posting before allocating new ones. Defaults to 2
+            max_postings_per_allocation (int, optional) How many job postings for each allocation.
+                Should be a number that is not so high as to be daunting for users at first,
+                but not so low as to make it a hassle to do several given that requesting
+                new allocations is not automatic.
+                Defaults to 10
+        """
+        logging.info('Starting experiment! Wait for a bit')
+        self.metadata['sample_base_path'] = sample.base_path
+        self.metadata['sample_name'] = sample.name
+        self.metadata['entities_with_shortcuts'] = entities_with_shortcuts
+        self.metadata['minimum_annotations_per_posting'] = minimum_annotations_per_posting
+        self.metadata['max_postings_per_allocation'] = max_postings_per_allocation
+
+        # 1. Output job posting text
+        self.metadata['units'] = {}
+        logging.info('Dividing sample into bundles of size %s', max_postings_per_allocation)
+        for unit_num, batch_postings in enumerate(Batch(sample, max_postings_per_allocation)):
+            unit_name = 'unit_{}'.format(unit_num)
+            self.metadata['units'][unit_name] = []
+            for posting_key, posting_string in enumerate(batch_postings):
+                posting = JobPosting(posting_string)
+                self.metadata['units'][unit_name].append((posting_key, posting.id))
+                outfilename = '/'.join([self.unit_path(unit_name), str(posting_key)])
+                logging.info('Writing to %s', outfilename)
+                with self.s3.open(outfilename + '.txt', 'wb') as f:
+                    f.write(posting.text.encode('utf-8'))
+                with self.s3.open(outfilename + '.ann', 'wb') as f:
+                    f.write(''.encode('utf-8'))
+        self.metadata.save()
+        logging.info('Done creating bundles. Now creating BRAT configuration')
+
+        # 2. Output annotation.conf with lists of entities
+        with self.s3.open('/'.join([self.brat_config_path, 'annotation.conf']), 'wb') as f:
+            f.write('[entities]\n'.encode('utf-8'))
+            for _, entity_name in entities_with_shortcuts:
+                f.write(entity_name.encode('utf-8'))
+                f.write('\n'.encode('utf-8'))
+            f.write('[relations]\n\n# none defined'.encode('utf-8'))
+            f.write('[attributes]\n\n# none defined'.encode('utf-8'))
+            f.write('[events]\n\n# none defined'.encode('utf-8'))
+
+        # 3. Output kb_shortcuts.conf with quick type selection for each entity
+        with self.s3.open('/'.join([self.brat_config_path, 'kb_shortcuts.conf']), 'wb') as f:
+            for shortcut, entity_name in entities_with_shortcuts:
+                to_write = shortcut + ' ' + entity_name + '\n'
+                f.write(to_write.encode('utf-8'))
+
+        # 4. Output visual.conf with list of entities
+        with self.s3.open('/'.join([self.brat_config_path, 'visual.conf']), 'wb') as f:
+            f.write('[labels]\n'.encode('utf-8'))
+            for _, entity_name in entities_with_shortcuts:
+                f.write(entity_name.encode('utf-8'))
+                f.write('\n'.encode('utf-8'))
+
+        logging.info('Done creating BRAT configuration. All data is at %s', self.experiment_path)
+
+    def add_user(self, username, password):
+        """Creates a user with an allocation
+
+        Args:
+            username (string) The desired username
+            password (string) The desired password
+        """
+        # Creates a user with an allocation.
+
+        if username in self.user_pw_store:
+            raise ValueError('User {} already created'.format(username))
+        self.user_pw_store[username] = password
+        self.user_pw_store.save()
+        return self.add_allocation(username)
+
+    def needs_allocation(self, unit_name):
+        """Whether or not this unit needs to be allocated again.
+
+        Args:
+            unit_name (string) The name of a unit (from experiment's .metadata['units']
+
+        Returns: (bool) Whether or not the unit should be allocated again
+        """
+        return sum([
+            1
+            for user_units in self.metadata['allocations'].values()
+            if unit_name in user_units
+        ]) < self.metadata['minimum_annotations_per_posting']
+
+    def add_allocation(self, user_name):
+        """Allocate a unit of job postings to the given user
+
+        Args:
+            user_name (string) A username (expected to be created already with a password)
+
+        Returns: (string) The directory containing job postings in the allocation
+        """
+        # given a user name
+        if user_name not in self.user_pw_store:
+            raise ValueError('Username not in user-password store. Please call add_user first')
+
+        # initialize allocations if there have been none yet
+        if 'allocations' not in self.metadata:
+            self.metadata['allocations'] = {}
+        if user_name not in self.metadata['allocations']:
+            self.metadata['allocations'][user_name] = []
+
+        # see if there is a next unit that the user hasn't seen and really needs allocation
+        unit_to_allocate = None
+        try:
+            unit_to_allocate = next(
+                unit_name
+                for unit_name in self.metadata['units'].keys()
+                if unit_name not in self.metadata['allocations'][user_name]
+                and self.needs_allocation(unit_name)
+            )
+        except StopIteration:
+            pass
+
+        # if there is none that really needs allocation
+        # just pick the next one they haven't seen yet
+        if not unit_to_allocate:
+            try:
+                unit_to_allocate = next(
+                    unit_name
+                    for unit_name in self.metadata['units'].keys()
+                    if unit_name not in self.metadata['allocations'][user_name]
+                )
+            except StopIteration:
+                pass
+
+        if not unit_to_allocate:
+            raise ValueError('No units left to allocate to user!')
+
+        # create and populate a directory for the user that has the contents of the unit
+        source_dir = self.unit_path(unit_to_allocate)
+        dest_dir = self.allocation_path(user_name, unit_to_allocate)
+
+        for source_key in self.s3.ls(source_dir):
+            dest_key = source_key.replace(source_dir, dest_dir)
+            self.s3.copy(source_key, dest_key)
+
+        # record in metadata the fact that the user has been allocated this
+        self.metadata['allocations'][user_name].append(unit_to_allocate)
+        self.metadata.save()
+        logging.info('Allocation created! Directory is %s', dest_dir)
+        return dest_dir
+
+    @cachedproperty
+    def annotations_by_unit(self):
+        """Fetch raw annotations by unit
+
+        Structure of return dictionary is as follows.
+            {'unit_name': {'posting_key': {'user_name': [annotations...]}}}
+            each annotation is a dictionary of: {
+                'entity' # the name of the configured entity (e.g. Skill) that the user annotated
+                'start_index': # the start index of the annotation in the text
+                'end_index': # the end index of the annotation in the text
+                'labeled_string': # the text string that the user annotated
+            }
+        Returns: (dict) The annotations by unit, posting key, and user name
+        """
+        # create annotations by unit
+        annotations_by_unit = {}
+        for user_name, unit_names in self.metadata['allocations'].items():
+            for unit_name in unit_names:
+                if unit_name not in annotations_by_unit:
+                    annotations_by_unit[unit_name] = {}
+                allocation_path = self.allocation_path(user_name, unit_name)
+                for key in self.s3.ls(allocation_path + '/'):
+                    # this will iterate through both posting text (.txt) and annotation (.ann)
+                    # files, in this case we really only care about the annotations
+                    if key.endswith('.ann'):
+                        posting_key = key.split('/')[-1].replace('.ann', '')
+                        with self.s3.open(key) as f:
+                            logging.info('Reading annotation file at %s', key)
+                            raw_annotations = csv.reader(f, delimiter='\t')
+                            if posting_key not in annotations_by_unit[unit_name]:
+                                annotations_by_unit[unit_name][posting_key] = {}
+
+                            converted_annotations = []
+                            for annotation in raw_annotations:
+                                logging.info('Found annotation line %s', annotation)
+                                index, middle, string = annotation
+                                entity, start, end = middle.split(' ')
+                                converted_annotations.append({
+                                    'entity': entity,
+                                    'start_index': int(start),
+                                    'end_index': int(end),
+                                    'labeled_string': string
+                                })
+                            annotations_by_unit[unit_name][posting_key][user_name] = \
+                                converted_annotations
+
+        return annotations_by_unit
+
+    def average_observed_agreement(self):
+        """Calculate average observed agreement by unit and posting key
+
+        Computed *per-label* and averaged together.
+
+        As an example:
+        Assume a job posting has four total annotations from two separate annotators.
+        Of these four, three are distinct. Each annotator agreed on one annotation, and each
+        of them had an extra one that didn't agree with each other.
+        The calculation is the mean of: [
+            1.0 (the one they agreed on)
+            0.5 (the one that annotator one tagged on their own)
+            0.5 (the one that annotator two tagged on their own)
+        ]
+        The end result for this job posting will be 1.0+0.5+0.5/3, or ~0.667
+
+        Structure of return dictionary is as follows.
+            {'unit_name': {'posting_key': 0.5}}
+        Returns: (dict) The average observed agreement by unit and posting key
+        """
+        # calculate average observed agreement
+        agreement = deepcopy(self.labels_with_agreement_by_unit)
+        for unit_name, posting_annotations in self.labels_with_agreement_by_unit.items():
+            for posting_key, annotations in posting_annotations.items():
+                if len(annotations) > 0:
+                    agreement[unit_name][posting_key] = mean(
+                        annotation['percent_tagged']
+                        for annotation in annotations
+                    )
+                else:
+                    agreement[unit_name][posting_key] = None
+        return agreement
+
+    @cachedproperty
+    def labels_with_agreement_by_unit(self):
+        """Fetch annotations with agreement by unit and job posting
+
+        Structure of return dictionary is as follows.
+            {'unit_name': {'posting_key': [annotations...]}}
+            each annotation is a dictionary of: {
+                'entity' # the name of the configured entity (e.g. Skill) that the user/s annotated
+                'start_index': # the start index of the annotation in the text
+                'end_index': # the end index of the annotation in the text
+                'labeled_string': # the text string that the user/s annotated
+                'percent_tagged': # of users that saw this posting, what percentage tagged this
+                'number_seen' # how many users saw this job posting
+            }
+        Returns: (dict) The annotations by unit and posting key
+        """
+        labels_with_agreement = deepcopy(self.annotations_by_unit)
+        for unit_name, posting_annotations in self.annotations_by_unit.items():
+            for posting_key, user_annotations in posting_annotations.items():
+                # to obtain a matrix, use the start/end indices as keys
+                keyed_user_annotations = {}
+                all_users = user_annotations.keys()
+                for user_name, converted_annotations in user_annotations.items():
+                    for converted_annotation in converted_annotations:
+                        key = (
+                            converted_annotation['start_index'],
+                            converted_annotation['end_index'],
+                            converted_annotation['entity'],
+                            converted_annotation['labeled_string']
+                        )
+                        if key not in keyed_user_annotations:
+                            keyed_user_annotations[key] = []
+                        keyed_user_annotations[key].append(user_name)
+
+                merged_annotations = []
+                for key, users_who_tagged in keyed_user_annotations.items():
+                    users_who_did_not_tag = [u for u in all_users]
+                    for user in users_who_tagged:
+                        users_who_did_not_tag.remove(user)
+                    percentage_tagged = len(users_who_tagged) / len(all_users)
+                    merged_annotations.append({
+                        'start_index': key[0],
+                        'end_index': key[1],
+                        'entity': key[2],
+                        'labeled_string': key[3],
+                        'percent_tagged': percentage_tagged,
+                        'number_seen': len(all_users)
+                    })
+                labels_with_agreement[unit_name][posting_key] = \
+                    sorted(merged_annotations, key=lambda k: k['start_index'])
+
+        return labels_with_agreement
+
+    @cachedproperty
+    def labels_with_agreement(self):
+        """Fetch flattened annotations with percent agreement
+            Each annotation is a dictionary of: {
+                'entity' # the name of the configured entity (e.g. Skill) that the user/s annotated
+                'start_index': # the start index of the annotation in the text
+                'end_index': # the end index of the annotation in the text
+                'labeled_string': # the text string that the user/s annotated
+                'percent_tagged': # of users that saw this posting, what percentage tagged this
+                'number_seen' # how many users saw this job posting
+                'job_posting_id' # the globally unique job posting id (from the original sample)
+            }
+        Returns: (list) The annotations with percent agreement
+        """
+        by_unit = self.labels_with_agreement_by_unit
+        flattened_labels = []
+        for unit, unit_annotations in by_unit.items():
+            posting_id_lookup = dict(self.metadata['units'][unit])
+            for posting_key, posting_annotations in unit_annotations.items():
+                logging.info(
+                    'Looking up posting key %s in job posting id lookup %s',
+                    posting_key,
+                    posting_id_lookup
+                )
+                job_posting_id = posting_id_lookup[int(posting_key)]
+                for annotation in posting_annotations:
+                    annotation['job_posting_id'] = job_posting_id
+                    flattened_labels.append(annotation)
+        # take labels with agreement by unit
+        # flatten, taking unit/posting key and looking up job posting id to include in dict
+        return flattened_labels

--- a/tests/evaluation/test_annotators.py
+++ b/tests/evaluation/test_annotators.py
@@ -307,12 +307,13 @@ def test_BratExperiment_labels_with_agreement():
             (1, 'ABC_4823943'),
         ]
     }
+    experiment.metadata['sample_name'] = 'test-sample'
     experiment.metadata.save()
     assert experiment.labels_with_agreement == [
-        {'job_posting_id': 'ABC_91238', 'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling', 'percent_tagged': 1.0, 'number_seen': 2},
-        {'job_posting_id': 'ABC_4823943', 'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming', 'percent_tagged': 1.0, 'number_seen': 2},
-        {'job_posting_id': 'ABC_4823943', 'entity': 'Skill', 'start_index': 39, 'end_index': 65, 'labeled_string': 'substance abuse counseling', 'percent_tagged': 0.5, 'number_seen': 2},
-        {'job_posting_id': 'ABC_4823943', 'entity': 'Skill', 'start_index': 49, 'end_index': 65, 'labeled_string': 'abuse counseling', 'percent_tagged': 0.5, 'number_seen': 2}
+        {'job_posting_id': 'ABC_91238', 'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling', 'percent_tagged': 1.0, 'number_seen': 2, 'sample_name': 'test-sample'},
+        {'job_posting_id': 'ABC_4823943', 'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming', 'percent_tagged': 1.0, 'number_seen': 2, 'sample_name': 'test-sample'},
+        {'job_posting_id': 'ABC_4823943', 'entity': 'Skill', 'start_index': 39, 'end_index': 65, 'labeled_string': 'substance abuse counseling', 'percent_tagged': 0.5, 'number_seen': 2, 'sample_name': 'test-sample'},
+        {'job_posting_id': 'ABC_4823943', 'entity': 'Skill', 'start_index': 49, 'end_index': 65, 'labeled_string': 'abuse counseling', 'percent_tagged': 0.5, 'number_seen': 2, 'sample_name': 'test-sample'}
     ]
 
 

--- a/tests/evaluation/test_annotators.py
+++ b/tests/evaluation/test_annotators.py
@@ -1,0 +1,419 @@
+from skills_ml.evaluation.annotators import BratExperiment
+from skills_ml.algorithms.sampling import Sample
+from moto import mock_s3, mock_s3_deprecated
+import boto3
+import json
+import s3fs
+from unittest.mock import MagicMock
+import pytest
+import unittest
+
+
+@mock_s3_deprecated
+@mock_s3
+def test_BratExperiment_start():
+    # create a bucket that will contain both the source samples and BRAT config
+    s3 = boto3.resource('s3')
+    bucket = s3.create_bucket(Bucket='test-bucket')
+
+    # create a sample.
+    # sample format is one file, one job posting per line, in common schema JSON format
+    bucket.put_object(
+        Body='\n'.join(json.dumps({'id': i, 'description': str(i)}) for i in range(100, 200)),
+        Key='samples/300_weighted'
+    )
+
+    experiment = BratExperiment(
+        experiment_name='initial_skills_tag',
+        brat_s3_path='test-bucket/brat'
+    )
+    experiment.start(
+        sample=Sample(base_path='s3://test-bucket/samples', sample_name='300_weighted'),
+        minimum_annotations_per_posting=2,
+        max_postings_per_allocation=20,
+        entities_with_shortcuts=(
+            ('c', 'Competency'),
+        )
+    )
+
+    # find metadata about what it created
+    s3 = s3fs.S3FileSystem()
+
+    # first assert that some shallow metadata was passed through
+    assert experiment.metadata['sample_base_path'] == 's3://test-bucket/samples'
+    assert experiment.metadata['sample_name'] == '300_weighted'
+    assert experiment.metadata['entities_with_shortcuts'] == (('c', 'Competency'),)
+    assert experiment.metadata['minimum_annotations_per_posting'] == 2
+    assert experiment.metadata['max_postings_per_allocation'] == 20
+
+    # next look at the posting texts themselves.
+    # we expect them all of them to be present but split across a number of units
+    units = experiment.metadata['units']
+    assert len(units) == 5  # 100/20
+    retrieved_descriptions = []
+    for unit_name, documents in units.items():
+        for posting_key, original_job_id in documents:
+            # we should not expose the original posting ids
+            # otherwise we don't care what the keys are but that they exist where we expect them to
+            assert posting_key is not original_job_id
+            with s3.open('{data_path}/.{unit_name}/{posting_key}.txt'.format(
+                    data_path=experiment.data_path,
+                    unit_name=unit_name,
+                    posting_key=posting_key
+            ), mode='rb') as f:
+                posting = f.read().decode('utf-8')
+                retrieved_descriptions.append(posting.strip())
+            # make sure that the blank annotation file is there too
+            with s3.open('{data_path}/.{unit_name}/{posting_key}.ann'.format(
+                    data_path=experiment.data_path,
+                    unit_name=unit_name,
+                    posting_key=posting_key
+            ), mode='rb') as f:
+                assert len(f.read().decode('utf-8')) == 0
+    # our fake descriptions were just the string values for the range numbers
+    # so that's what should get written
+    assert sorted(retrieved_descriptions) == sorted([str(i) for i in range(100, 200)])
+
+    def assert_conf_contains(conf_name, expected):
+        with s3.open('{path}/{conf_name}'.format(
+                path=experiment.brat_config_path,
+                conf_name=conf_name
+        ), 'rb') as f:
+            assert expected in f.read().decode('utf-8')
+
+    assert_conf_contains('visual.conf', '[labels]\nCompetency\n')
+    assert_conf_contains('annotation.conf', '[entities]\nCompetency\n')
+    assert_conf_contains('kb_shortcuts.conf', 'c Competency\n')
+
+
+@mock_s3
+def test_BratExperiment_add_user():
+    # given a valid brat experiment,
+    # call add_user with a username and password
+    # expect the user/pass to be added to config.py,
+    # and for the user to be added to the experiment's metadata
+    # and for add_allocation to be called with the user
+
+    # setup: create a bucket for the brat config
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket='test-bucket')
+    # initialize the experiment in this bucket
+    experiment = BratExperiment(
+        experiment_name='initial_skills_tag',
+        brat_s3_path='test-bucket/brat'
+    )
+
+    # setup the add_allocation mock for later inspection
+    add_allocation_mock = MagicMock()
+    experiment.add_allocation = add_allocation_mock
+
+    # add a user
+    experiment.add_user('user', 'pass')
+
+    # assert metadata
+    assert 'user' in experiment.user_pw_store
+
+    # assert that we attempted to allocate postings to them
+    add_allocation_mock.assert_called_with('user')
+
+
+@mock_s3
+@mock_s3_deprecated
+def test_BratExperiment_add_allocation():
+    # given a user name
+    # find the next allocation to use that the user has not annotated yet
+    # create a directory with the users name
+    # record in metadata the fact that the user has been allocated this
+
+    # setup: create a bucket for the brat config
+    s3 = boto3.resource('s3')
+    bucket = s3.create_bucket(Bucket='test-bucket')
+    bucket.put_object(
+        Body='\n'.join(json.dumps({'id': i, 'description': str(i)}) for i in range(100, 200)),
+        Key='samples/300_weighted'
+    )
+
+    experiment = BratExperiment(
+        experiment_name='initial_skills_tag',
+        brat_s3_path='test-bucket/brat'
+    )
+    experiment.start(
+        sample=Sample(base_path='s3://test-bucket/samples', sample_name='300_weighted'),
+        minimum_annotations_per_posting=2,
+        max_postings_per_allocation=20,
+        entities_with_shortcuts=(
+            ('c', 'Competency'),
+        )
+    )
+    # initialize the experiment in this bucket
+    experiment = BratExperiment(
+        experiment_name='initial_skills_tag',
+        brat_s3_path='test-bucket/brat'
+    )
+
+    username = 'testuser'
+    # should not be able to allocate without creating a user
+    with pytest.raises(ValueError):
+        experiment.add_allocation(username)
+
+    # set up a user to allocate to
+    experiment.user_pw_store[username] = 'password'
+    experiment.user_pw_store.save()
+    allocated_directory = experiment.add_allocation(username)
+
+    allocations = experiment.metadata['allocations'][username]
+    assert len(allocations) == 1
+
+    s3 = s3fs.S3FileSystem()
+    filenames = s3.ls(allocated_directory)
+    # there should be two files for each job posting: the .txt. and the .ann
+    assert len(filenames) == len(experiment.metadata['units'][allocations[0]]) * 2
+
+    # simulate continued allocation with more users
+    user_two = 'user_two'
+    user_three = 'user_three'
+    experiment.add_user(user_two, 'pass')
+    experiment.add_user(user_three, 'pass')
+    for i in range(0, 4):
+        experiment.add_allocation(user_two)
+        experiment.add_allocation(user_three)
+    # at this point, trying to re-allocate to either user two or three
+    # should fail as they have now tagged everything
+    with pytest.raises(ValueError):
+        experiment.add_allocation(user_two)
+
+    # user one should still work for now
+    for i in range(0, 4):
+        new_directory = experiment.add_allocation(username)
+        assert new_directory != allocated_directory
+
+    # once they have seen the whole thing, no more!
+    with pytest.raises(ValueError):
+        experiment.add_allocation(username)
+
+
+@mock_s3
+@mock_s3_deprecated
+def test_BratExperiment_average_observed_agreement():
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket='test-bucket')
+
+    experiment = BratExperiment(
+        experiment_name='initial_skills_tag',
+        brat_s3_path='test-bucket/brat'
+    )
+
+    annotations_by_unit = {}
+    annotations_by_unit['unit_1'] = {
+        '0': {
+            'user_1': [
+                {'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling'}
+            ],
+            'user_2': [
+                {'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling'}
+            ]
+        },
+        '1': {
+            'user_1': [
+                {'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming'},
+                {'entity': 'Skill', 'start_index': 39, 'end_index': 65, 'labeled_string': 'substance abuse counseling'}
+            ],
+            'user_2': [
+                {'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming'},
+                {'entity': 'Skill', 'start_index': 49, 'end_index': 65, 'labeled_string': 'abuse counseling'}
+            ],
+        }
+    }
+    experiment.annotations_by_unit = annotations_by_unit
+    assert experiment.average_observed_agreement() == {'unit_1': {'0': 1, '1': 2/3}}
+
+
+class TestLabelsWithAgreementByUnit(unittest.TestCase):
+    @mock_s3
+    @mock_s3_deprecated
+    def test_labels_with_agreement_by_unit(self):
+        s3 = boto3.resource('s3')
+        bucket = s3.create_bucket(Bucket='test-bucket')
+
+        experiment = BratExperiment(
+            experiment_name='initial_skills_tag',
+            brat_s3_path='test-bucket/brat'
+        )
+
+        annotations_by_unit = {}
+        annotations_by_unit['unit_1'] = {
+            '0': {
+                'user_1': [
+                    {'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling'}
+                ],
+                'user_2': [
+                    {'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling'}
+                ]
+            },
+            '1': {
+                'user_1': [
+                    {'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming'},
+                    {'entity': 'Skill', 'start_index': 39, 'end_index': 65, 'labeled_string': 'substance abuse counseling'}
+                ],
+                'user_2': [
+                    {'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming'},
+                    {'entity': 'Skill', 'start_index': 49, 'end_index': 65, 'labeled_string': 'abuse counseling'}
+                ],
+            }
+        }
+        experiment.annotations_by_unit = annotations_by_unit
+        expected = {
+            'unit_1': {
+                '0': [
+                    {'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling', 'percent_tagged': 1.0, 'number_seen': 2}
+                ],
+                '1': [
+                    {'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming', 'percent_tagged': 1.0, 'number_seen': 2},
+                    {'entity': 'Skill', 'start_index': 39, 'end_index': 65, 'labeled_string': 'substance abuse counseling', 'percent_tagged': 0.5, 'number_seen': 2},
+                    {'entity': 'Skill', 'start_index': 49, 'end_index': 65, 'labeled_string': 'abuse counseling', 'percent_tagged': 0.5, 'number_seen': 2}
+                ]
+            }
+        }
+        self.maxDiff = None
+        self.assertDictEqual(experiment.labels_with_agreement_by_unit, expected)
+
+
+@mock_s3
+@mock_s3_deprecated
+def test_BratExperiment_labels_with_agreement():
+    s3 = boto3.resource('s3')
+    bucket = s3.create_bucket(Bucket='test-bucket')
+
+    experiment = BratExperiment(
+        experiment_name='initial_skills_tag',
+        brat_s3_path='test-bucket/brat'
+    )
+    labels_by_unit = {
+        'unit_1': {
+            '0': [
+                {'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling', 'percent_tagged': 1.0, 'number_seen': 2}
+            ],
+            '1': [
+                {'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming', 'percent_tagged': 1.0, 'number_seen': 2},
+                {'entity': 'Skill', 'start_index': 39, 'end_index': 65, 'labeled_string': 'substance abuse counseling', 'percent_tagged': 0.5, 'number_seen': 2},
+                {'entity': 'Skill', 'start_index': 49, 'end_index': 65, 'labeled_string': 'abuse counseling', 'percent_tagged': 0.5, 'number_seen': 2}
+            ]
+        }
+    }
+    experiment.labels_with_agreement_by_unit = labels_by_unit
+    experiment.metadata['units'] = {
+        'unit_1': [
+            (0, 'ABC_91238'),
+            (1, 'ABC_4823943'),
+        ]
+    }
+    experiment.metadata.save()
+    assert experiment.labels_with_agreement == [
+        {'job_posting_id': 'ABC_91238', 'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling', 'percent_tagged': 1.0, 'number_seen': 2},
+        {'job_posting_id': 'ABC_4823943', 'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming', 'percent_tagged': 1.0, 'number_seen': 2},
+        {'job_posting_id': 'ABC_4823943', 'entity': 'Skill', 'start_index': 39, 'end_index': 65, 'labeled_string': 'substance abuse counseling', 'percent_tagged': 0.5, 'number_seen': 2},
+        {'job_posting_id': 'ABC_4823943', 'entity': 'Skill', 'start_index': 49, 'end_index': 65, 'labeled_string': 'abuse counseling', 'percent_tagged': 0.5, 'number_seen': 2}
+    ]
+
+
+@mock_s3
+@mock_s3_deprecated
+def test_BratExperiment_annotations_by_unit():
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket='test-bucket')
+
+    experiment = BratExperiment(
+        experiment_name='initial_skills_tag',
+        brat_s3_path='test-bucket/brat'
+    )
+
+    # directory structure
+    # 2 different units with 2 job postings each, 2 users each
+    # calculate inter-rater reliability per job-posting
+
+    job_postings = {
+        'unit_1/0': 'this is a job description which talks about substance abuse counseling',
+        'unit_1/1': 'job description python programming and substance abuse counseling',
+        'unit_2/0': 'hello we want a person who is skilled with offender orientation and intervention techniques',
+        'unit_2/1': 'development of positive social skills is important to us and also intervention techniques'
+    }
+    tags = {
+        'user_1': {
+            'unit_1/0': [
+                'T1\tSkill 44 70\tsubstance abuse counseling',
+            ],
+            'unit_1/1': [
+                'T1\tSkill 16 33\tpython programming',
+                'T2\tSkill 39 65\tsubstance abuse counseling',
+            ]
+        },
+        'user_2': {
+            'unit_1/0': [
+                'T1\tSkill 44 70\tsubstance abuse counseling',
+            ],
+            'unit_1/1': [
+                'T1\tSkill 16 33\tpython programming',
+                'T2\tSkill 49 65\tabuse counseling',
+            ]
+        },
+        'user_3': {
+            'unit_2/0': [
+                'T1\tSkill 43 62\toffender orientation',
+                'T2\tSkill 68 90\tintervention techniques',
+            ],
+            'unit_2/1': [
+                'T1\tSkill 0 36\tdevelopment of positive social skills',
+                'T2\tSkill 66 88\tintervention techniques',
+            ]
+        },
+        'user_4': {
+            'unit_2/0': [
+                'T1\tSkill 43 62\toffender orientation',
+                'T2\tSkill 68 90\tintervention techniques',
+            ],
+            'unit_2/1': []
+        },
+    }
+    experiment.metadata['units'] = {}
+    for key in job_postings.keys():
+        unit_name, num = key.split('/')
+        if unit_name not in experiment.metadata['units']:
+            experiment.metadata['units'][unit_name] = []
+        experiment.metadata['units'][unit_name].append((key, key))
+
+    experiment.metadata['allocations'] = {}
+    for user_name, annotations in tags.items():
+        experiment.metadata['allocations'][user_name] = []
+        for key, annotation_lines in annotations.items():
+            unit_name, num = key.split('/')
+            if unit_name not in experiment.metadata['allocations'][user_name]:
+                experiment.metadata['allocations'][user_name].append(unit_name)
+
+            base_path = '{}/{}'.format(experiment.user_allocations_path(user_name), key)
+            with experiment.s3.open('{}.txt'.format(base_path), 'wb') as f:
+                f.write(job_postings[key].encode('utf-8'))
+            with experiment.s3.open('{}.ann'.format(base_path), 'wb') as f:
+                f.write('\n'.join(annotation_lines).encode('utf-8'))
+    experiment.metadata.save()
+
+    assert experiment.annotations_by_unit['unit_1'] == {
+        '0': {
+            'user_1': [
+                {'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling'}
+            ],
+            'user_2': [
+                {'entity': 'Skill', 'start_index': 44, 'end_index': 70, 'labeled_string': 'substance abuse counseling'}
+            ]
+        },
+        '1': {
+            'user_1': [
+                {'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming'},
+                {'entity': 'Skill', 'start_index': 39, 'end_index': 65, 'labeled_string': 'substance abuse counseling'}
+            ],
+            'user_2': [
+                {'entity': 'Skill', 'start_index': 16, 'end_index': 33, 'labeled_string': 'python programming'},
+                {'entity': 'Skill', 'start_index': 49, 'end_index': 65, 'labeled_string': 'abuse counseling'}
+            ],
+        }
+    }
+


### PR DESCRIPTION
Functionality to manage a BRAT experiment using a named job posting sample.
Adds a new class, called BratExperiment. This is meant to encompass the following management tasks:

- Creating empty annotation files for all job postings in the sample, in the format that BRAT can read
- Dividing up job postings into allocations based on configuration
- Adding new users and initial allocations
- Adding new allocations to existing users
- Storing all relevant metadata on s3
- Parsing the results of user annotations into labels

This pull request just implements the tasks around the starting and management of experiments. The tasks around parsing the results are deferred to be implemented in a future pull request.

It is not meant to cover the installation of BRAT, or any other devops/infrastructure tasks, which would be out of scope of this repository. Installations are meant to sync this data from S3 on their own.