### PR TITLE
Move filtering from CorpusCreator to JobPostingFilterer

### DIFF
--- a/examples/Creating Corpus and Sampled Corpus.ipynb
+++ b/examples/Creating Corpus and Sampled Corpus.ipynb
@@ -2,51 +2,23 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2018-03-28 17:53:13,213] {__init__.py:36} INFO - Using executor SequentialExecutor\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Eddie/Documents/DSSG/WDI/skills-ml/venv/lib/python3.5/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use \"pip install psycopg2-binary\" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.\n",
-      "  \"\"\")\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2018-03-28 17:53:14,006] {textcleaner.py:20} INFO - 'pattern' package not found; tag filters are not available for English\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%reload_ext autoreload\n",
     "%autoreload 2\n",
     "import sys\n",
     "sys.path.append('../')\n",
-    "from airflow.hooks import S3Hook\n",
-    "s3_conn = S3Hook().get_conn()\n",
-    "from skills_ml.job_postings.common_schema import JobPostingGenerator\n",
+    "from skills_ml.job_postings.common_schema import JobPostingCollectionSample\n",
+    "from skills_ml.job_postings.filtering import JobPostingFilterer, soc_major_group_filter\n",
     "import random\n",
     "import json\n",
     "from skills_ml.job_postings.corpora.basic import Doc2VecGensimCorpusCreator, CorpusCreator\n",
     "from collections import Counter\n",
     "import numpy as np\n",
     "from skills_ml.job_postings.sample import JobSampler\n",
-    "import logging\n",
-    "logger = logging.getLogger()\n",
-    "assert len(logger.handlers) == 1\n",
-    "handler = logger.handlers[0]\n",
-    "handler.setLevel(logging.WARNING)"
+    "import logging"
    ]
   },
   {
@@ -65,58 +37,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "job_postings_generator = JobPostingGenerator(\n",
-    "    s3_conn=s3_conn, \n",
-    "    quarters=['2011Q2'], \n",
-    "    s3_path='open-skills-private/test_corpus', \n",
-    "    source=\"all\"\n",
-    ")\n",
-    "# job_postings_generator = job_postings_chain(s3_conn, ['2011Q2'], 'open-skills-private/test_corpus')\n",
-    "corpus = CorpusCreator(job_postings_generator)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Eddie/Documents/DSSG/WDI/skills-ml/venv/lib/python3.5/site-packages/bs4/__init__.py:219: UserWarning: \"b'.'\" looks like a filename, not markup. You should probably open this file and pass the filehandle into Beautiful Soup.\n",
-      "  ' Beautiful Soup.' % markup)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "corpus = list(corpus)"
+    "job_postings_generator = JobPostingCollectionSample()\n",
+    "corpus = CorpusCreator(job_postings_generator)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "10567"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "len(corpus)"
+    "corpus = list(corpus)"
    ]
   },
   {
@@ -127,31 +62,52 @@
     {
      "data": {
       "text/plain": [
-       "{'@context': 'http://schema.org',\n",
-       " '@type': 'JobPosting',\n",
-       " 'alternateName': 'Payroll Specialist',\n",
-       " 'baseSalary': {'@type': 'MonetaryAmount', 'maxValue': 0.0, 'minValue': 0.0},\n",
-       " 'datePosted': '2012-06-20',\n",
-       " 'description': 'Position Summary: The Payroll Specialist is responsible for processing all payroll information for accurate and timely payroll distribution. Responsibilities: Process store-level biweekly payroll accurately and timely Import store employee info and time clock data Research and resolve employee payroll issues Process involuntary wage withholding correspondence Respond promptly to all requests and communications received Review and process adjustments to hours/earnings Maintain employee direct deposit records Assist with various projects as assigned GREAT OPPORTUNITY!',\n",
-       " 'educationRequirements': 'Graduate Degree',\n",
-       " 'employmentType': 'Full-Time',\n",
-       " 'experienceRequirements': 'Qualifications: 1-3 years of general payroll experience Positive attitude combined with excellent communication skills Possess the ability to work well under pressure and meet deadlines Must be detail oriented with strong organization skills Possess general knowledge of involuntary wage deductions and federal and multistate payroll tax laws Ability to work with minimal supervision, prioritize tasks and maintain confidentiality Dedicated to providing an accurate payroll product in a team environment Excellent attendance history Experience Preferred: · High School education · Multi-unit or restaurant payroll experience is a plus · ADP Payforce and ADP Reporting experience is a plus · Microsoft Office Suite',\n",
-       " 'id': 'CB_159324388',\n",
-       " 'incentiveCompensation': '',\n",
-       " 'industry': 'Accounting - Finance, Full Service Restaurant, Food',\n",
-       " 'jobLocation': {'@type': 'Place',\n",
-       "  'address': {'@type': 'PostalAddress',\n",
-       "   'addressLocality': 'Farmers Branch',\n",
-       "   'addressRegion': 'TX'}},\n",
-       " 'occupationalCategory': '',\n",
-       " 'onet_soc_code': None,\n",
-       " 'qualifications': 'Qualifications: 1-3 years of general payroll experience Positive attitude combined with excellent communication skills Possess the ability to work well under pressure and meet deadlines Must be detail oriented with strong organization skills Possess general knowledge of involuntary wage deductions and federal and multistate payroll tax laws Ability to work with minimal supervision, prioritize tasks and maintain confidentiality Dedicated to providing an accurate payroll product in a team environment Excellent attendance history Experience Preferred: · High School education · Multi-unit or restaurant payroll experience is a plus · ADP Payforce and ADP Reporting experience is a plus · Microsoft Office Suite',\n",
-       " 'skills': 'Finance, Restaurant - Food Service, Accounting',\n",
-       " 'title': 'Payroll Specialist',\n",
-       " 'validThrough': '2012-07-20T00:00:00'}"
+       "50"
       ]
      },
      "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(corpus)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'@context': 'http://schema.org',\n",
+       " '@type': 'JobPosting',\n",
+       " 'title': 'Media Consultant',\n",
+       " 'description': \"Media consultant. Email. tweet. Location:Vienna, Va.. Date posted: 03-11-2016. Apply now. Job Summary: the Public Sector Group, a division of 1105 media, is seeking an experienced media consultant sales professional who enjoys a fast-paced leading edge environment and a variety of assignments with an innovative media company. The Media Consultant & Sales Representative will support a myriad of online and print products providing a genuine relational and consultative approach with customers to foster repeat business. The portfolio includes print publications, websites, e-newsletters, web seminars, custom media, research and other Online & print products. This position involves business development and account prospecting, face-to-face and phone selling, networking at industry events, putting together and making presentations, preparing proposals, closing sales, managing print and online programs, and customer service. Essential Responsibilities: drive advertising revenue with aggressive sales efforts that penetrate new markets and increase existing market presence. Consult with customers to be able to properly articulate the value proposition of a product package that exceeds customer goals and aligns with the business direction. Build customer relationships on an ongoing basis. Accelerate growing online business through vast knowledge of digital products, deliverables and metrics. Weekly forecasting and reporting. Work with staff to develop creative advertising packages - both print and online. Minimum Requirements: College degree preferred. 2-5 years experience in print and/or online advertising sales and be able to show consistent sales results in previous positions. Knowledge of the IT industry is preferred. Track record of creativity in sales approaches and solutions. Track record of successfully meeting and exceeding sales goals in media sales relevant to 1105 media's line of business. Excellent client presentation and communication skills as well as strong customer service and organizational skills. The ideal candidate is energetic, self-motivated, team-oriented, and customer-centric. REQUIRED PROFICIENCY IN MS office applications and experience with crm software. Understanding of how to research potential customers and use online analytics from a sales perspective. Weekly local travel to meet with clients/prospects is required. Minimal non local travel a few times a year is required. Corporate Profile: 1105 Media, Inc. is a leading provider of integrated business-to-business information and media. The markets we serve include government, education, Network & ENTERPRISE COMPUTING, Business Intelligence, Industrial Health & Safety, compliance, security, environmental protection, water & Wastewater, and home medical equipment. Our products focus on technology, products, policy, regulation, and news delivered through an assortment of media including print and online magazines, journals, and newsletters; seminars, conferences, executive summits, and trade shows; training and courseware; and web-based services. 1105 media is based in Chatsworth, CA, with offices throughout the United States and more than 200 employees. The CEO is Rajeev Kapur. We offer a competitive salary and a comprehensive benefits package that includes medical/dental/vision insurance, life insurance, disability insurance, 401-LRB-K-RRB- plan and a generous paid time off -LRB-Pto-RRB-/holiday plan. We are proud to be an equal opportunity employer\",\n",
+       " 'educationRequirements': '',\n",
+       " 'employmentType': '',\n",
+       " 'experienceRequirements': 'College degree preferred, 2-5 years experience in print and/or online advertising sales and be able to show consistent sales results in previous positions, Knowledge of the IT industry is preferred, Track record of creativity in sales approaches and solutions, Track record of successfully meeting and exceeding sales goals in media sales relevant to 1105 Medias line of business, Excellent client presentation and communication skills as well as strong customer service and organizational skills, The ideal candidate is energetic, self-motivated, team-oriented, and customer-centric, Understanding of how to research potential customers and use online analytics from a sales perspective, Weekly local travel to meet with clients/prospects is required, Minimal non local travel a few times a year is required',\n",
+       " 'incentiveCompensation': '',\n",
+       " 'qualifications': '',\n",
+       " 'occupationalCategory': '41-3011.00, 27-3031.00, 11-2021.00, 41-3011.00, 27-3031.00, 11-2021.00, 41-3011.00, 27-3031.00, 11-2021.00, 41-3011.00, 27-3031.00, 11-2021.00',\n",
+       " 'skills': '',\n",
+       " 'datePosted': '2016-03-17',\n",
+       " 'validThrough': None,\n",
+       " 'jobLocation': {'@type': 'Place',\n",
+       "  'address': {'@type': 'PostalAddress',\n",
+       "   'addressLocality': 'Vienna',\n",
+       "   'addressRegion': 'Virginia'}},\n",
+       " 'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "  'minValue': 0.0,\n",
+       "  'maxValue': 0.0,\n",
+       "  'medianValue': 90000.0},\n",
+       " 'industry': '51',\n",
+       " 'onet_soc_code': '27-3031.00'}"
+      ]
+     },
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -176,26 +132,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 31,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def major_group_filter_func(document):\n",
     "    if document['onet_soc_code']:\n",
     "        if document['onet_soc_code'][:2] in ['11', '13']:\n",
-    "            return document\n",
+    "            return True\n",
     "\n",
     "def full_soc_code_filter_func(document):\n",
     "    if document['onet_soc_code']:\n",
-    "        if document['onet_soc_code'] in ['11-9051.00', '17-3026.00']:\n",
-    "            return document\n",
+    "        if document['onet_soc_code'] in ['13-1041.01']:\n",
+    "            return True\n",
     "\n",
     "def wage_filter_func(document):\n",
-    "    if document['baseSalary']['minValue']:\n",
-    "        if float(document['baseSalary']['minValue']) >= 60000.0:\n",
-    "            return document"
+    "    if document['baseSalary']['medianValue']:\n",
+    "        if float(document['baseSalary']['medianValue']) >= 60000.0:\n",
+    "            return True"
    ]
   },
   {
@@ -207,42 +161,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "job_postings_generator = JobPostingGenerator(\n",
-    "    s3_conn=s3_conn, \n",
-    "    quarters=['2011Q2'], \n",
-    "    s3_path='open-skills-private/test_corpus', \n",
-    "    source=\"all\"\n",
-    ")\n",
-    "corpus = CorpusCreator(job_postings_generator, filter_func=major_group_filter_func)"
+    "job_postings_generator = JobPostingCollectionSample()\n",
+    "filtered_job_postings = JobPostingFilterer(job_postings_generator, filter_funcs=[major_group_filter_func])\n",
+    "corpus = CorpusCreator(filtered_job_postings)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Eddie/Documents/DSSG/WDI/skills-ml/venv/lib/python3.5/site-packages/bs4/__init__.py:219: UserWarning: \"b'.'\" looks like a filename, not markup. You should probably open this file and pass the filehandle into Beautiful Soup.\n",
-      "  ' Beautiful Soup.' % markup)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "corpus = list(corpus)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -250,29 +189,30 @@
       "text/plain": [
        "{'@context': 'http://schema.org',\n",
        " '@type': 'JobPosting',\n",
-       " 'alternateName': 'General Manager',\n",
-       " 'baseSalary': {'@type': 'MonetaryAmount', 'maxValue': 0.0, 'minValue': 0.0},\n",
-       " 'datePosted': '2012-09-17',\n",
-       " 'description': 'If you are a personable, outgoing and service-oriented professional who wants to manage a dynamic office, come join the Kool Smiles family! Kool Smiles was founded in 2002 and was built on the belief that every family has the right to quality dental care in a clean, safe and fun environment. Our first goal is to provide quality and compliant dental care to individuals in communities that typically get overlooked by other dentists. Our services aren’t just for kids- we know that children are more likely to have great dental habits if mom and dad do too, so we happily care for the entire family. Kool Smiles is looking for a customer-service-oriented leader to fill the role of Office Manager. As the Office Manager, you will manage an office staff of 15 to 30 employees and provide a friendly environment for the numerous patients who come to us for dental care. Job Responsibilities As the Office Manager for Kool Smiles, you will interview and hire new employees as well as coach and counsel existing staff. You will also develop a team atmosphere among office staff and encourage them to perform at their highest level. You will also handle a wide range of organizational and supervisory duties, including: • Ensuring outstanding patient satisfaction • Ensuring compliance standards are met at all times • Achieving office level financial performance targets • Scheduling staff and conducting performance-management programs • Promoting Kool Smiles brand throughout community via local marketing efforts • Maintaining the appearance and overall efficiency of the office Job Requirements As the Manager, you will be the public face of Kool Smiles. You must be professional in your appearance and manner and be able to interact well with children as they comprise approximately 80% of our patients. You must also have excellent problem-solving and verbal and written communication skills. Specific qualifications for the Office Manager position include: • Minimum 5 years experience managing 10 or more direct reports in a customer-service-focused role, preferably in a retail, hospitality, restaurant or medical setting where you had direct and face-to-face interaction with customers • Proficiency with Microsoft Office Suite • Demonstrated ability to drive business results • Public-service experience is a plus, as many of our patients are children from low-income families in medically underserved communities • Bachelor’s degree is preferred, but not required Benefits At Kool Smiles, you will begin your role as Office Manager with a two-week training course in Atlanta. You will also have the opportunity to advance to positions such as District Manager, Area Business Leader, and Certified Office Manager (which involves setting-up and training staff for new Kool Smiles offices.) Additional benefits include: • Medical and dental insurance • 401(k) • Short-term and long-term disability • Bonus plan based on the performance of the office • Paid vacation • Paid holidays Take on a new challenge and make a positive community impact! Apply today!',\n",
-       " 'educationRequirements': 'Not Specified',\n",
-       " 'employmentType': 'Full-Time',\n",
-       " 'experienceRequirements': '#',\n",
-       " 'id': 'CB_757175032',\n",
+       " 'title': 'State Inspector- Chesapeake',\n",
+       " 'description': \"Primary Job Functions: Perform va state inspections. Perform oil changes and lubrication services to automobiles. Perform tire repairs and installation services to automobiles. Perform any other basic repairs to automobiles as assigned by a lead tech or manager/service manager/service writer according to his/her abilities. This could include but not be limited to brakes, suspension, alignments, parts changing, exhaust, ac/heating, maintenance inspections, and tune-ups. Gain on the job experience in all areas of automotive repair and strive to obtain ASE certifications. Clean shop and grounds during down time. Assist with transporting customers/parts and running errands. Keep his/her work area clean and safe. Various miscellaneous duties as assigned by lead tech or management. Assists other level technicians as requested. Performs other duties as assigned. Automotive repair knowledge -Minimum 1 year automotive repair experience with Va State Inspector License. must provide own full set of tools. CUSTOMER RELATIONS & INTERPERSONAL SKILLS- must be able to understand and meet customers' needs and expectations. must use good interpersonal skills in solving customers' problems and build positive relationships with them. Communication skills -must be able to communicate with others in a clear, understandable manner. Problem Solving and resource allocation -must be able to analyze information, identify alternatives, and make sound, logical decisions. Must Maximize utilization of available resources. Teamwork & Cooperation -must be able to build smooth, cooperative working relationships, assisting other team members when possible. Time Management and multi-tasking -must be able to perform multiple tasks and use time efficiently. Must be able to deal with negative emotions from others, displaying a positive, caring attitude on each interaction. FLEXIBILITY & Adaptability -must be able to adapt to change and be flexible in adjusting approach to meet the needs of different situations. must be able to rotate among job functions as needed. . Job: Automotive Services. Organization: CCC Oh - Chesapeake Battlefiel -LRB-03632.47.5410-RRB-. Title: State Inspector- Chesapeake. Location: Virginia-Chesapeake -LRB-VA-RRB-. REQUISITION ID: 11317\",\n",
+       " 'educationRequirements': '',\n",
+       " 'employmentType': '',\n",
+       " 'experienceRequirements': '',\n",
        " 'incentiveCompensation': '',\n",
-       " 'industry': 'Healthcare - Health Services, Retail, Food',\n",
+       " 'qualifications': '',\n",
+       " 'occupationalCategory': '49-3023.02, 49-3023.01, 49-1011.00, 49-3023.02, 49-3023.01, 49-1011.00, 49-3023.02, 49-3023.01, 49-1011.00, 49-3023.02, 49-3023.01, 49-1011.00',\n",
+       " 'skills': '',\n",
+       " 'datePosted': '2016-03-17',\n",
+       " 'validThrough': None,\n",
        " 'jobLocation': {'@type': 'Place',\n",
        "  'address': {'@type': 'PostalAddress',\n",
-       "   'addressLocality': 'Lafayette',\n",
-       "   'addressRegion': 'IN'}},\n",
-       " 'occupationalCategory': 'Food Service Managers',\n",
-       " 'onet_soc_code': '11-9051.00',\n",
-       " 'qualifications': '#',\n",
-       " 'skills': 'Retail, Management, Health Care',\n",
-       " 'title': 'General Manager seeking change-No Late Nights/Sundays',\n",
-       " 'validThrough': '2012-11-19T00:00:00'}"
+       "   'addressLocality': 'Chesapeake',\n",
+       "   'addressRegion': 'Virginia'}},\n",
+       " 'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "  'minValue': 0.0,\n",
+       "  'maxValue': 0.0,\n",
+       "  'medianValue': 0.0},\n",
+       " 'industry': '',\n",
+       " 'onet_soc_code': '13-1041.01'}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -283,10 +223,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [],
    "source": [
     "major_group = list(map(lambda c: c['onet_soc_code'][:2], corpus))"
@@ -294,16 +232,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({'11': 283, '13': 102})"
+       "Counter({'13': 3, '11': 8})"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -321,43 +259,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "job_postings_generator = JobPostingGenerator(\n",
-    "    s3_conn=s3_conn, \n",
-    "    quarters=['2011Q2'], \n",
-    "    s3_path='open-skills-private/test_corpus', \n",
-    "    source=\"all\"\n",
-    ")\n",
-    "corpus = CorpusCreator(job_postings_generator, filter_func=full_soc_code_filter_func)"
+    "job_postings_generator = JobPostingCollectionSample()\n",
+    "filtered_job_postings = JobPostingFilterer(job_postings_generator, filter_funcs=[full_soc_code_filter_func])\n",
+    "corpus = CorpusCreator(filtered_job_postings)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Eddie/Documents/DSSG/WDI/skills-ml/venv/lib/python3.5/site-packages/bs4/__init__.py:219: UserWarning: \"b'.'\" looks like a filename, not markup. You should probably open this file and pass the filehandle into Beautiful Soup.\n",
-      "  ' Beautiful Soup.' % markup)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "corpus = list(corpus)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 20,
+   "metadata": {},
    "outputs": [],
    "source": [
     "soc = list(map(lambda c: c['onet_soc_code'], corpus))"
@@ -365,16 +288,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({'11-9051.00': 79, '17-3026.00': 65})"
+       "Counter({'13-1041.01': 3})"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -387,77 +310,90 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Filtered by Minimum Wage >= 60000"
+    "Filtered by Median Wage >= 60000"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 32,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "job_postings_generator = JobPostingGenerator(\n",
-    "    s3_conn=s3_conn, \n",
-    "    quarters=['2011Q2'], \n",
-    "    s3_path='open-skills-private/test_corpus', \n",
-    "    source=\"all\"\n",
-    ")\n",
-    "corpus = CorpusCreator(job_postings_generator, filter_func=wage_filter_func)"
+    "job_postings_generator = JobPostingCollectionSample()\n",
+    "filtered_job_postings = JobPostingFilterer(job_postings_generator, filter_funcs=[wage_filter_func])\n",
+    "corpus = CorpusCreator(filtered_job_postings)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "corpus = list(corpus)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "min_wage = list(map(lambda c: c['baseSalary']['minValue'], corpus))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({60000.0: 8,\n",
-       "         65000.0: 10,\n",
-       "         70000.0: 4,\n",
-       "         71110: 1,\n",
-       "         75000.0: 5,\n",
-       "         80000.0: 10,\n",
-       "         83221: 1,\n",
-       "         85000.0: 1,\n",
-       "         90000.0: 12,\n",
-       "         100000.0: 2,\n",
-       "         120000.0: 3,\n",
-       "         160000.0: 1})"
+       "((({'@context': 'http://schema.org',\n",
+       "    '@type': 'JobPosting',\n",
+       "    'title': 'Automotive Service Manager-Chesapeake Car Care Center',\n",
+       "    'description': \"Job Responsibilities. Primary Job Functions: manages all customer relations and ensures that employees are providing above average customer service. Investigates and resolves all customer disputes, including warranty issues. Manages the profit and loss of the center, including expense control, pricing structure, and mark up of parts. Oversees inventory control, including managing vendor relations and approving all purchases and stocking activities. Oversees facility maintenance. Assist with oversight of the fleet drivers based out of the center. Supervises technicians and other employees at the center. This includes employee relations, hiring, firing, disciplining, and scheduling. Tracks employee productivity using management software. Maximizes sales and profitability by maintaining and scheduling appropriate work loads according to operation hours and employee availability. Ensures the safe operation of the center according to company guidelines and all federal, state, and local regulations. This includes conducting monthly safety meetings. Prepares and analyzes statistical reports and utilize this information in managing trends and profitability. Continually develops plans, programs, and promotions to increase production and customer service satisfaction levels. Schedules and conducts ongoing training sessions, utilizing outside resources if needed and approved by senior management. Assists Service writer in the preparation of estimates and work orders. Assists technicians with diagnosing and repairs if needed. Makes Recommendations for advertisements if needed. Makes Recommendations to senior management about center operations as needed. Performs other duties as assigned. Required knowledge, skills & Abilities. 1. Automotive Repair Knowledge - extensive knowledge of the automotive repair industry required. Minimum 5 years experience in automotive repair. ASE certifications are preferred, with the strongest preference to ASE master certification. 2. CUSTOMER RELATIONS & Interpersonal Skills - must be able to understand and meet customers' needs and expectations. must use good interpersonal skills in solving customers' problems and build positive relationships with them. 3. Communication skills - must be able to communicate with others in a clear, understandable manner. 4. Problem Solving and resource allocation - must be able to analyze information, identify alternatives, and make sound, logical decisions. Must maximize utilization of available resources. 5. TEAMWORK & Cooperation - must be able to build smooth, cooperative working relationships, assisting other team members when possible. 6. Time Management and multi-tasking - must be able to perform multiple tasks and use time efficiently. Must be able to deal with negative emotions from others, displaying a positive, caring attitude on each interaction. 7. FLEXIBILITY & Adaptability - must be able to adapt to change and be flexible in adjusting approach to meet the needs of different situations. must be able to rotate among job functions as needed. 8. Management Ability - must be able to assess strengths and weaknesses of staff and develop their abilities; must be able to enforce company policies and procedures. Minimum 3 years management experience required. Job: Car Care Centers. Organization: CCC Oh - Chesapeake Battlefiel -LRB-03632.47.5410-RRB-. TITLE: Automotive Service Manager-Chesapeake Car Care Center. Location: Virginia-Chesapeake -LRB-VA-RRB-. REQUISITION ID: 11624\",\n",
+       "    'educationRequirements': '',\n",
+       "    'employmentType': '',\n",
+       "    'experienceRequirements': '',\n",
+       "    'incentiveCompensation': '',\n",
+       "    'qualifications': '',\n",
+       "    'occupationalCategory': '43-1011.01, 49-1011.00, 41-1012.00, 43-1011.00, 49-1011.00, 41-1012.00, 43-1011.00, 49-1011.00, 41-1012.00, 43-1011.00, 49-1011.00, 41-1012.00',\n",
+       "    'skills': '',\n",
+       "    'datePosted': '2016-03-17',\n",
+       "    'validThrough': None,\n",
+       "    'jobLocation': {'@type': 'Place',\n",
+       "     'address': {'@type': 'PostalAddress',\n",
+       "      'addressLocality': 'Chesapeake',\n",
+       "      'addressRegion': 'Virginia'}},\n",
+       "    'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "     'minValue': 0.0,\n",
+       "     'maxValue': 0.0,\n",
+       "     'medianValue': 0.0},\n",
+       "    'industry': '',\n",
+       "    'onet_soc_code': ''},),),)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "Counter(min_wage)"
+    "corpus = list(corpus)\n",
+    "corpus[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "median_wage = list(map(lambda c: c['baseSalary']['medianValue'], corpus))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({90000.0: 1, 68000.0: 1, 84000.0: 1, 94000.0: 3, 102000.0: 1})"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Counter(median_wage)"
    ]
   },
   {
@@ -476,44 +412,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 57,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "job_postings_generator = JobPostingGenerator(\n",
-    "    s3_conn=s3_conn, \n",
-    "    quarters=['2011Q2'], \n",
-    "    s3_path='open-skills-private/test_corpus', \n",
-    "    source=\"all\"\n",
-    ")\n",
+    "job_postings_generator = JobPostingCollectionSample()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "corpus = CorpusCreator(job_postings_generator)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 59,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Eddie/Documents/DSSG/WDI/skills-ml/venv/lib/python3.5/site-packages/bs4/__init__.py:219: UserWarning: \"b'.'\" looks like a filename, not markup. You should probably open this file and pass the filehandle into Beautiful Soup.\n",
-      "  ' Beautiful Soup.' % markup)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from skills_ml.job_postings.sample import JobSampler\n",
     "job_sampler = JobSampler(corpus, random_state=42)\n",
-    "corpus = job_sampler.sample(100)"
+    "corpus = job_sampler.sample(10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
@@ -521,31 +449,30 @@
       "text/plain": [
        "({'@context': 'http://schema.org',\n",
        "  '@type': 'JobPosting',\n",
-       "  'alternateName': 'Customer Service Representative',\n",
-       "  'baseSalary': {'@type': 'MonetaryAmount',\n",
-       "   'maxValue': 11.0,\n",
-       "   'minValue': 11.0},\n",
-       "  'datePosted': '2011-08-25',\n",
-       "  'description': 'We are currently looking for bilingual (Spanish- English) customer service representative. You need to be fluent in both languages, clerical experience, be customer service oriented and have a professional appearance. If you think you have great customer service skills, have a strong work ethic and want to be part of a great team please contact me',\n",
-       "  'educationRequirements': 'Not Specified',\n",
-       "  'employmentType': 'Full-Time',\n",
-       "  'experienceRequirements': 'MINIMUM QUALIFICATIONS: High school diploma and some college coursework or equivalent Capable of solving a variety of customer service problems and supporting a range of personalities and customer types Bi-lingual: Spanish Ability to communicate effectively with others, orally and written',\n",
-       "  'id': 'CB_-126168718',\n",
+       "  'title': 'Sr. Network Engineer',\n",
+       "  'description': \"Sr.. Network engineer. Job Title: Sr.. Network engineer. Job Type: Full-Time. Location: Herndon, Va.. Post date: 06/11/2012. Job Description: Position Summary: This is an exempt position that manages large complex function-LRB-s-RRB- and provides direct supervision to groups involved in network integration and implementation. Responsible for the planning and implementation of programs and projects that adhere to approved plans, budgets and schedules. Provides specialized technical and administrative and business development expertise. Coordinates and facilitates with internal and external resources to effect the timely completion of projects. Coordinates closely with customer representatives to ensure all customer needs are met. Will work at customer sites most of the time but will support all of ESP needs including business development. The primary purpose, product and/or service of the Unit-LRB-s-RRB- managed may involve highly technical activities or programs; or policies, procedures, controls and services required to support the sound financial, operational and competitive position of the company. Reports to manager, ESP. RESPONSIBILITES: Plan and implement Customer Network;. Maintain Customer Network and identify growth potential;. Acquire, install, configure, test and maintain customer network equipment;. Work closely with customer to determine future customer network growth and expand capabilities;. Maintain relationship with customers to develop future opportunities for AboveNet;. Assist in proposal writing and customer communications;. Must be able to act on his own and make decisions while dealing with very aggressive schedules and impatient customers;. Must always have a backup plan as ESP customers tend to change direction at the last minute;. Knowledge of various network topologies and protocol's is very important;. Maintain very strict customer security requirements;. The individual must comply with departmental and corporate internal controls and all internal controls processes;. The individual must possess and employ the highest ethical and business standards and always conduct himself/herself with the greatest degree of professional integrity;. Other duties and responsibilities as required. Requirements: a Bachelors Degree or equivalent experience;. 7+ years of experience;. Technical understanding of the components of the telecommunications network and a demonstrated ability to quickly assimilate technical data, methods and procedures;. Knowledge of various network topologies and protocol's is very important;. Must be able to perform effectively in an unstructured environment;. must communicate effectively, possess strong organizing, planning and interpersonal skills to lead and motivate a diverse group performing multiple assignments in a rapidly changing technological environment. Please visit our website at www.above.net. ABOVENET communications, INC is an equal opportunity employer.\",\n",
+       "  'educationRequirements': '',\n",
+       "  'employmentType': '',\n",
+       "  'experienceRequirements': '',\n",
        "  'incentiveCompensation': '',\n",
-       "  'industry': 'Consumer Products, Other, Food',\n",
+       "  'qualifications': '',\n",
+       "  'occupationalCategory': '15-1071.00, 15-1081.00, 15-1099.99, 15-1071.00, 15-1081.00, 15-1099.02, 15-1142.00, 15-1143.00, 15-1199.02, 15-1142.00, 15-1143.00, 15-1199.02',\n",
+       "  'skills': '',\n",
+       "  'datePosted': '2016-03-17',\n",
+       "  'validThrough': None,\n",
        "  'jobLocation': {'@type': 'Place',\n",
        "   'address': {'@type': 'PostalAddress',\n",
-       "    'addressLocality': 'Las Vegas',\n",
-       "    'addressRegion': 'NV'}},\n",
-       "  'occupationalCategory': '',\n",
-       "  'onet_soc_code': None,\n",
-       "  'qualifications': 'MINIMUM QUALIFICATIONS: High school diploma and some college coursework or equivalent Capable of solving a variety of customer service problems and supporting a range of personalities and customer types Bi-lingual: Spanish Ability to communicate effectively with others, orally and written',\n",
-       "  'skills': 'Customer Service, Information Technology, Admin - Clerical',\n",
-       "  'title': 'Bilingual Customer Service - Spanish',\n",
-       "  'validThrough': '2012-07-18T00:00:00'},)"
+       "    'addressLocality': 'Herndon',\n",
+       "    'addressRegion': 'Virginia'}},\n",
+       "  'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "   'minValue': 0.0,\n",
+       "   'maxValue': 0.0,\n",
+       "   'medianValue': 94000.0},\n",
+       "  'industry': '51',\n",
+       "  'onet_soc_code': '15-1142.00'},)"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -556,10 +483,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 62,
+   "metadata": {},
    "outputs": [],
    "source": [
     "industry = list(map(lambda c: c[0]['industry'], corpus))"
@@ -567,38 +492,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({'': 59,\n",
-       "         'Advertising, Sales - Marketing, Hospitality': 1,\n",
-       "         'Biotechnology, Pharmaceutical, Food': 1,\n",
-       "         'Consulting, Sales - Marketing, Hospitality': 1,\n",
-       "         'Consumer Products, Other, Food': 1,\n",
-       "         'Consumer Products, Sales - Marketing, Food': 2,\n",
-       "         'Education - Teaching - Administration, Social Services, Food': 1,\n",
-       "         'Entertainment, Food, Hospitality': 1,\n",
-       "         'Entertainment, Retail, Hospitality': 1,\n",
-       "         'Hospitality, Restaurant, Food': 4,\n",
-       "         'Not for Profit - Charitable, Healthcare - Health Services, Food': 1,\n",
-       "         'Packaging, Manufacturing, Food': 1,\n",
-       "         'Public Relations, Not for Profit - Charitable, Food': 1,\n",
-       "         'Restaurant, Food, Hospitality': 7,\n",
-       "         'Restaurant, Full Service Restaurant, Hospitality': 1,\n",
-       "         'Restaurant, Managed Care, Hospitality': 1,\n",
-       "         'Restaurant, Retail, Hospitality': 6,\n",
-       "         'Retail, Restaurant, Food': 1,\n",
-       "         'Sales - Marketing, Consulting, Hospitality': 1,\n",
-       "         'Sales - Marketing, Consumer Products, Food': 1,\n",
-       "         'Sales - Marketing, Retail, Food': 5,\n",
-       "         'Transportation, Airline - Aviation, Hospitality': 1,\n",
-       "         'Transportation, Travel, Hospitality': 1})"
+       "Counter({'51': 1, '': 6, '33': 1, '54': 2})"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -623,46 +526,277 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 64,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "job_postings_generator = JobPostingGenerator(\n",
-    "    s3_conn=s3_conn, \n",
-    "    quarters=['2011Q2'], \n",
-    "    s3_path='open-skills-private/test_corpus', \n",
-    "    source=\"all\"\n",
-    ")\n",
+    "job_postings_generator = JobPostingCollectionSample()\n",
     "corpus = CorpusCreator(job_postings_generator, filter_func=major_group_filter_func)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 65,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Eddie/Documents/DSSG/WDI/skills-ml/venv/lib/python3.5/site-packages/bs4/__init__.py:219: UserWarning: \"b'.'\" looks like a filename, not markup. You should probably open this file and pass the filehandle into Beautiful Soup.\n",
-      "  ' Beautiful Soup.' % markup)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "job_sampler = JobSampler(corpus, random_state=42)\n",
-    "corpus = job_sampler.sample(100)"
+    "corpus = job_sampler.sample(10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[({'@context': 'http://schema.org',\n",
+       "   '@type': 'JobPosting',\n",
+       "   'title': 'Sr. Network Engineer',\n",
+       "   'description': \"Sr.. Network engineer. Job Title: Sr.. Network engineer. Job Type: Full-Time. Location: Herndon, Va.. Post date: 06/11/2012. Job Description: Position Summary: This is an exempt position that manages large complex function-LRB-s-RRB- and provides direct supervision to groups involved in network integration and implementation. Responsible for the planning and implementation of programs and projects that adhere to approved plans, budgets and schedules. Provides specialized technical and administrative and business development expertise. Coordinates and facilitates with internal and external resources to effect the timely completion of projects. Coordinates closely with customer representatives to ensure all customer needs are met. Will work at customer sites most of the time but will support all of ESP needs including business development. The primary purpose, product and/or service of the Unit-LRB-s-RRB- managed may involve highly technical activities or programs; or policies, procedures, controls and services required to support the sound financial, operational and competitive position of the company. Reports to manager, ESP. RESPONSIBILITES: Plan and implement Customer Network;. Maintain Customer Network and identify growth potential;. Acquire, install, configure, test and maintain customer network equipment;. Work closely with customer to determine future customer network growth and expand capabilities;. Maintain relationship with customers to develop future opportunities for AboveNet;. Assist in proposal writing and customer communications;. Must be able to act on his own and make decisions while dealing with very aggressive schedules and impatient customers;. Must always have a backup plan as ESP customers tend to change direction at the last minute;. Knowledge of various network topologies and protocol's is very important;. Maintain very strict customer security requirements;. The individual must comply with departmental and corporate internal controls and all internal controls processes;. The individual must possess and employ the highest ethical and business standards and always conduct himself/herself with the greatest degree of professional integrity;. Other duties and responsibilities as required. Requirements: a Bachelors Degree or equivalent experience;. 7+ years of experience;. Technical understanding of the components of the telecommunications network and a demonstrated ability to quickly assimilate technical data, methods and procedures;. Knowledge of various network topologies and protocol's is very important;. Must be able to perform effectively in an unstructured environment;. must communicate effectively, possess strong organizing, planning and interpersonal skills to lead and motivate a diverse group performing multiple assignments in a rapidly changing technological environment. Please visit our website at www.above.net. ABOVENET communications, INC is an equal opportunity employer.\",\n",
+       "   'educationRequirements': '',\n",
+       "   'employmentType': '',\n",
+       "   'experienceRequirements': '',\n",
+       "   'incentiveCompensation': '',\n",
+       "   'qualifications': '',\n",
+       "   'occupationalCategory': '15-1071.00, 15-1081.00, 15-1099.99, 15-1071.00, 15-1081.00, 15-1099.02, 15-1142.00, 15-1143.00, 15-1199.02, 15-1142.00, 15-1143.00, 15-1199.02',\n",
+       "   'skills': '',\n",
+       "   'datePosted': '2016-03-17',\n",
+       "   'validThrough': None,\n",
+       "   'jobLocation': {'@type': 'Place',\n",
+       "    'address': {'@type': 'PostalAddress',\n",
+       "     'addressLocality': 'Herndon',\n",
+       "     'addressRegion': 'Virginia'}},\n",
+       "   'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "    'minValue': 0.0,\n",
+       "    'maxValue': 0.0,\n",
+       "    'medianValue': 94000.0},\n",
+       "   'industry': '51',\n",
+       "   'onet_soc_code': '15-1142.00'},),\n",
+       " ({'@context': 'http://schema.org',\n",
+       "   '@type': 'JobPosting',\n",
+       "   'title': 'Insurance Agent',\n",
+       "   'description': \"1. Complete applications for insurance. Prepare and communicate insurance premium quotations. 2. Respond to customer inquiries and make recommendations regarding coverage for new and existing insurance policies. 3. Process policy changes as requested by customers. Follow up with customers for company requested information. 4. Accept Insurance premium payments and process for delivery to appropriate carriers. 5. Document all customer contacts and correspondence. 6. Screen and underwrite prospects using established company and agency guidelines for proper placement with agency carriers. 7. Take first loss reports as required. Advise insureds of claims procedures and assist them with the claims process as needed. 8. Diary and follow up with claims adjusters and related personnel to ensure prompt claim handling. 9. Assist in Problem Resolution -LRB-i.e., refund of cancellation requests, reinstatements, rewrites, service complaints, etc.-RRB-. 10. Review assigned accounts for cross sale and upgrade potential. 11. Assist customers with their needs on a first come, first served basis, subject to insurance licensing requirements, regardless of which employee issued the customer's policy or prepared the quotation for coverage. Current license of P&C;. Previous experience in selling policies. Must be able to work M-F 8:30AM-5:30PM. 1. Customer relations and interpersonal skills-- understanding and anticipating members' needs and expectations, and striving to meet or exceed those expectations; using good customer relations and interpersonal skills in helping solve members' problems and answer their questions. 2. Active listening-- listening to, interpreting, understanding, and processing verbal information; probing to ensure all key information is obtained from member. 3. Communication and telephone skills-- using proper telephone etiquette and speaking in a clear, understandable manner; tactfully controlling interactions in order to efficiently obtain and give necessary information; clearly explaining itineraries, costs, and other travel related information; preparing written communications and documents. 4. Decision making and problem solving-- Analyzing Information, identifying alternatives, and making sound, logical decisions; deviating from standard procedures when appropriate for delivering excellent member service, subject to the agency agreements with the various insurance companies. 5. Teamwork, cooperation, professionalism-- must be able to build and maintain smooth, cooperative working relationships with each fellow employee, assisting other team members when possible, maintaining a professional working demeanor at all times. 6. Dealing with high volume-- dealing effectively with high volume and time pressure; displaying a positive, caring attitude with each customer and with fellow employees. 7. Flexibility and adaptability-- adapting to change and being flexible in adjusting approach to meet the needs in different situations. Job: FSU. Organization: FSU - Suffolk -LRB-00500.47.5402-RRB-. TITLE: Insurance Agent. Location: Virginia-Suffolk -LRB-VA-RRB-. REQUISITION ID: 11104\",\n",
+       "   'educationRequirements': '',\n",
+       "   'employmentType': '',\n",
+       "   'experienceRequirements': '',\n",
+       "   'incentiveCompensation': '',\n",
+       "   'qualifications': '',\n",
+       "   'occupationalCategory': '41-3021.00, 43-4051.00, 43-9041.02, 41-3021.00, 43-4051.00, 43-9041.02, 41-3021.00, 43-4051.00, 43-9041.02, 41-3021.00, 43-4051.00, 43-9041.02',\n",
+       "   'skills': '',\n",
+       "   'datePosted': '2016-03-17',\n",
+       "   'validThrough': None,\n",
+       "   'jobLocation': {'@type': 'Place',\n",
+       "    'address': {'@type': 'PostalAddress',\n",
+       "     'addressLocality': 'Suffolk',\n",
+       "     'addressRegion': 'Virginia'}},\n",
+       "   'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "    'minValue': 0.0,\n",
+       "    'maxValue': 0.0,\n",
+       "    'medianValue': 47000.0},\n",
+       "   'industry': '',\n",
+       "   'onet_soc_code': '41-3021.00'},),\n",
+       " ({'@context': 'http://schema.org',\n",
+       "   '@type': 'JobPosting',\n",
+       "   'title': 'City Driver Full-Time Combined Dock/P&D',\n",
+       "   'description': \"ABF freight is looking for self-motivated, hardworking and energetic city drivers. Our city drivers play a vital role in maintaining strong customer relationships. ABF freight drivers use up-to-date technology to do their jobs effectively and efficiently. We recognize the importance of our drivers and that's why our turnover rate is so low. This is your chance to start your career with the ABF freight team!. Job Responsibilities include, but are not limited to the following: pickup and delivery of cargo to and from various destinations usually within proximity of the consolidation/distribution center loading and unloading of trailers utilizing the same techniques, technology and procedures as a dock worker acutal duties and schedule May vary depending on terminal location. QUALIFICATIONS: Our drivers should be at least 21 years old. We are looking for applicants with a minimum of 1 year tractor/trailer experience. If you have less than 1 year experience, you may be eligible for training. A Class A CDL with doubles/triples, tanker and Hazmat endorsements are required. We are looking for drivers with a stable work record and strong work ethic to add to our exceptional team. Safe driving records -LRB-MVR as well as previous employers-RRB- are required for our employees. All drivers must pass a dot pre-employment drug screen and meet DOT medical requirements. BENEFITS: Make More money!wages are teamster union scale which are greater than most other carriers! City drivers also receive overtime pay after 8 hours/day. Be Home more often!home time for ABF freight drivers far exceeds that of other drivers within the truckload industry. Vast majority of ABF freight local driving jobs aremonday through Friday. All drivers receive health and welfare benefits withno employee paid premiums. Each employee receives 5 days of sick leave each January 1st. With the amount of personal days, sick leave, and paid holidays, an employee may qualify for up to 4 weeks paid days off without using vacation. Life Insurance is provided through the multi-employer sponsored health and Welfare Fund. Employees are given the opportunity to contribute to a company sponsored 401-LRB-K-RRB-. ABF freight employees are covered by a pension plan ATNO EXPENSETO the employee. Drivers participate in a profit sharing program with option to purchase company stock through a stock purchase PLAN.ABF-CAT-DRV\",\n",
+       "   'educationRequirements': '',\n",
+       "   'employmentType': '',\n",
+       "   'experienceRequirements': '',\n",
+       "   'incentiveCompensation': '',\n",
+       "   'qualifications': 'Our drivers should be at least 21 years old., We are looking for applicants with a minimum of 1 year tractor/trailer experience. If you have less than 1 year experience, you may be eligible for training., A Class A CDL with doubles/triples, tanker and HAZMAT endorsements are required., We are looking for drivers with a stable work record and strong work ethic to add to our exceptional team., Safe driving records (MVR as well as previous employers) are required for our employees., All drivers must pass a DOT pre-employment drug screen and meet DOT medical requirements.',\n",
+       "   'occupationalCategory': '53-3032.02, 53-3033.00, 53-3031.00, 53-3032.00, 53-3033.00, 53-3031.00, 53-3032.00, 53-3033.00, 53-3031.00, 53-3032.00, 53-3033.00, 53-3031.00',\n",
+       "   'skills': '',\n",
+       "   'datePosted': '2016-03-17',\n",
+       "   'validThrough': None,\n",
+       "   'jobLocation': {'@type': 'Place',\n",
+       "    'address': {'@type': 'PostalAddress',\n",
+       "     'addressLocality': 'Manassas',\n",
+       "     'addressRegion': 'Virginia'}},\n",
+       "   'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "    'minValue': 0.0,\n",
+       "    'maxValue': 0.0,\n",
+       "    'medianValue': 25000.0},\n",
+       "   'industry': '',\n",
+       "   'onet_soc_code': '53-7062.00'},),\n",
+       " ({'@context': 'http://schema.org',\n",
+       "   '@type': 'JobPosting',\n",
+       "   'title': 'Acquisition Subject Matter Expert',\n",
+       "   'description': \"Overview:provide advice to the government in complying with the federal acquisition regulation and supplements from the DOD, IC, and agency. Develop policies and procedures for standardizing and Expediting Nga acquisitions. Communicate and market acquisition policy and efforts to internal and external customers. Assess current contracts, along with acquisition trends from other agencies' software development and commercial off-the-shelf -LRB-COTS-RRB- integration contracts, to identify opportunities for implementing acquisition reform principles. Manage and advise the requirements identification and documentation process. St. Michael's Inc. is a consulting firm whose mission is to assist and advise customers with improving business processes and realizing results. Our highly experienced professionals have supported customers from the Department of Defense, the intelligence community, and the Department of Homeland Security in the areas of: Audit Readiness Financial Management Governance Performance Management Process Management Enterprise financial system integration standardizing internal controls financial policy support metrics analysis. SUMMARY OF SKILLS and qualifications:St. Michael's Inc. is seeking a mid/senior level candidate who possess: 6-8 years of directly related special experience in a similar contracting environment. 8-12 years total experience required in acquisition management. Expertise in earned value management, portfolio management , program and Project Management Program office support, requirements management, risk management and system technical expertise. Aid in the development of acquisition strategies for new and follow on contracts. Ensure the technical and programmatic basis is consistent with Nga, dod, and IC acquisition reform and NGA architectural concepts. Assist with develop of acquisition strategy planning briefs and documents. Facilitate approval of acquisition strategies, plans, and documentation through the NGA approval process. Provide system security advice for multiple sites and systems, and recommend, implement, maintain, and review security documents and policies in support of ICD503 and DNI directed assessment and authorization -LRB-A&A;-RRB- requirements. Serve as source selection advisors. Coordinate the schedule, facilitation, and facility requirements for the mission partner source selection facility. Provide administrative support for source selections at the discretion of the source selection authority. Solid Analytical Ability, with excellent written and verbal communication skills. Ability to prepare written and verbal reports to project team and upper management regarding project performance. Must have the ability to work independently, and as strong member of a team\",\n",
+       "   'educationRequirements': '',\n",
+       "   'employmentType': '',\n",
+       "   'experienceRequirements': '',\n",
+       "   'incentiveCompensation': '',\n",
+       "   'qualifications': '',\n",
+       "   'occupationalCategory': '13-1111.00, 15-1051.00, 13-1081.00, 13-1111.00, 15-1051.00, 13-1081.00, 13-1111.00, 15-1121.00, 13-1081.00, 13-1111.00, 15-1121.00, 13-1081.00',\n",
+       "   'skills': '',\n",
+       "   'datePosted': '2016-03-17',\n",
+       "   'validThrough': None,\n",
+       "   'jobLocation': {'@type': 'Place',\n",
+       "    'address': {'@type': 'PostalAddress',\n",
+       "     'addressLocality': 'Potomac Mills',\n",
+       "     'addressRegion': 'Virginia'}},\n",
+       "   'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "    'minValue': 0.0,\n",
+       "    'maxValue': 0.0,\n",
+       "    'medianValue': 0.0},\n",
+       "   'industry': '',\n",
+       "   'onet_soc_code': ''},),\n",
+       " ({'@context': 'http://schema.org',\n",
+       "   '@type': 'JobPosting',\n",
+       "   'title': 'Senior Electrical Engineer',\n",
+       "   'description': \"Are you seeking a position where you can use your electrical engineering skills as part of a team to create an innovative solution to challenging industrial processes?. Do you enjoy being a part of a team that takes challenges head on requiring you to use the knowledge you have acquired and encourages you to think outside the box? Each project is different; no two are alike never allowing you to get bored. Projects are fast moving and exciting. As one of our senior electrical engineers, based in our headquarters south of Richmond in colonial heights, va you will be a part of a creative team that focuses on industrial processes giving our clients creative and innovative solutions that meet or exceed their expectations in performance, schedule, and budget. As a team member you will be responsible leading and developing the engineering for drawings and documentation to construct your solution; and then see your effort started up and work as part of the commissioning team. Your experience and professionalism is a vital part of this role. We are looking for an individual that can hit theground running. You will not be an island, but you will be assigned portions of the project that are your responsibility to complete on time, in scope, and in budget with minimal oversight. Your experience as an electrical engineer will be critical as you develop engineering calculations, draft/design constructible solutions, and coordinate with other disciplines. Advanced Process Solutions -LRB-APS-RRB- is a full-service multi-discipline engineering consulting firm offering a wide variety of technical services to an impressive list of worldwide clients. We provide experienced technical experts, engineers and designers to support our client's important initiatives. We partner with our clients and share their vision of success through the application of practical, constructible and fiscally responsible designs. APS serves a wide variety of industries including ethanol, biofuels, pharmaceuticals, specialty chemicals, films, fibers, plastics, mining, and pulp and paper. We thrive on exceeding the expectations of our clients. Advanced Process Solutions welcomes applications from women, minorities, veterans and persons with disabilities and seeks to build a culturally diverse business environment. Advanced process solutions is an equal opportunity/affirmative action employer. Roles and responsibilities. Lead electrical project team prepare designs, specifications, and drawings for power distribution, PLC/DCS systems, lighting, and grounding. Lead and assist in project management activities - reviewing and updating budget, preparing and updating project schedule, and maintaining project scope of work. Motor load list calculations including - service entrance, voltage drop, conduit fill conceptual design able to read P&ID; electrical specifications construction scopes of work and Specifications Construction Bid Packages Support Development of Project Engineering Bids Support Development of engineering scopes of Work Support Development of total install cost estimates development of scope change orders input to project schedule - development and ongoing client and vendor correspondence client and vendor meetings meeting minutes project status reporting site work - including as built conditions, locating power sources construction support/oversight Inter-discipline coordination and intra-discipline coordination with project team. Minimum qualifications. BSEE with 10+ years of Industrial De\",\n",
+       "   'educationRequirements': '',\n",
+       "   'employmentType': '',\n",
+       "   'experienceRequirements': '',\n",
+       "   'incentiveCompensation': '',\n",
+       "   'qualifications': '',\n",
+       "   'occupationalCategory': '17-2071.00, 17-2112.00, 17-2072.00, 17-2071.00, 17-2112.00, 17-2072.00, 17-2071.00, 17-2112.00, 17-2072.00, 17-2071.00, 17-2112.00, 17-2072.00',\n",
+       "   'skills': '',\n",
+       "   'datePosted': '2016-03-17',\n",
+       "   'validThrough': None,\n",
+       "   'jobLocation': {'@type': 'Place',\n",
+       "    'address': {'@type': 'PostalAddress',\n",
+       "     'addressLocality': 'Colonial Heights',\n",
+       "     'addressRegion': 'Virginia'}},\n",
+       "   'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "    'minValue': 0.0,\n",
+       "    'maxValue': 0.0,\n",
+       "    'medianValue': 0.0},\n",
+       "   'industry': '',\n",
+       "   'onet_soc_code': '17-2071.00'},),\n",
+       " ({'@context': 'http://schema.org',\n",
+       "   '@type': 'JobPosting',\n",
+       "   'title': 'Supply Specialist (SCA)',\n",
+       "   'description': \"Summary: This position performs limited aspects of Technical Supply Management Work -lrb-E.G., inventory management, storage management, cataloging, and property utilization-RRB- related to depot, local, or other supply activities. Essential duties and responsibilities: anticipates problems and works to proactively mitigate them. Reports to site lead -LRB-quality manager for advisement-RRB-. The work generally involves individual case problems or supply actions. Ensures product shipped to/from the site meet all applicable 14 CFR part 121/145 requirements. Inspects the in-bound/out-bound material for damage and proper documentation. Packages out-bound shipments by using best commercial practices. Inspects Oem or FAA form 8130-3 / certificate of conformance documentation for originality and serial number. Manage and control government property and materials in imops. Package materials for transportation, including Hazmat Materials IAW PWS requirements. Inspects the in-bound/out-bound material for damage and proper documentation. Packages out-bound shipments by using best commercial practices. Inspects Oem or FAA form 8130-3 / Certificate of conformance documentation for originality and serial number. Establish initial material control records in imops. Requisition new or refurbished/repair assets through imops. All other duties as assigned. To perform this job successfully, an individual must be able to perform each essential duty satisfactorily. The requirements listed are representative of the knowledge, skill, and/or ability required. Education and/or experience: Required: High School Diploma or equivalent required. Minimum of three -LRB-3-RRB- years' experience in a warehouse environment. Must have the ability to obtain a common access card -LRB-CAC-RRB-. Physical demands/working conditions: The physical demands and work environment characteristics described here are representative of those that must be met be an employee to successfully perform the essential functions of this job. Reasonable accommodations may be made to enable individuals with disabilities to perform the essential functions. While performing the duties of this job, the employee is regularly required to sit, stand, bend, reach, and move about the facility. Candidates should be able to adapt to a traditional business environment. In addition, this position requires the use of a computer, intermittent standing, walking, sitting, squatting, stretching, and bending throughout the workday. Must be able to see and hear, or use prosthetics that will enable these senses to function adequately to assure that the requirements of this position can be fully met. Job: OPERATIONS TITLE: Supply Specialist -LRB-SCA-RRB- location: Virginia-Virginia Beach Requisition Id: 5402\",\n",
+       "   'educationRequirements': '',\n",
+       "   'employmentType': '',\n",
+       "   'experienceRequirements': '',\n",
+       "   'incentiveCompensation': '',\n",
+       "   'qualifications': '',\n",
+       "   'occupationalCategory': '43-5081.03, 53-1031.00, 13-1081.00, 43-5081.03, 53-1031.00, 13-1081.00, 43-5081.03, 53-1031.00, 13-1081.00, 43-5081.03, 53-1031.00, 13-1081.00',\n",
+       "   'skills': '',\n",
+       "   'datePosted': '2016-03-17',\n",
+       "   'validThrough': None,\n",
+       "   'jobLocation': {'@type': 'Place',\n",
+       "    'address': {'@type': 'PostalAddress',\n",
+       "     'addressLocality': 'Virginia Beach',\n",
+       "     'addressRegion': 'Virginia'}},\n",
+       "   'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "    'minValue': 0.0,\n",
+       "    'maxValue': 0.0,\n",
+       "    'medianValue': 0.0},\n",
+       "   'industry': '33',\n",
+       "   'onet_soc_code': '15-1151.00'},),\n",
+       " ({'@context': 'http://schema.org',\n",
+       "   '@type': 'JobPosting',\n",
+       "   'title': 'Drafter',\n",
+       "   'description': 'ABB is seeking a drafter to prepare engineering drawings and data packages of moderate complexity for such products as components, hardware, assemblies and equipment, and perform other related duties for the manufacturing of small power transformers. Typical duties/responsibilities may include, but are not limited to, the following: Perform Mathematical calculations, use most appropriate drafting equipment such as computer aided design, related hardware/software or mechanical equipment and follow general instructions to produce drawings of moderately complex products, in accordance with departmental procedures and standard drafting practices. Check completed drawings for accuracy, completeness, design practices and standard applications. Independently resolve minor problems and seek assistance from more experienced staff to resolve more complex issues. Review contract files, standard practices and codes for specific applications. Work with senior drafting personnel to complete drafting packages and ensure conformance to contract specifications. Complete scheduled tasks in a timely manner and adhere to scheduled tasks and completion dates.',\n",
+       "   'educationRequirements': '',\n",
+       "   'employmentType': '',\n",
+       "   'experienceRequirements': '',\n",
+       "   'incentiveCompensation': '',\n",
+       "   'qualifications': '',\n",
+       "   'occupationalCategory': '17-3013.00, 17-3012.01, 17-3012.02, 17-3013.00, 17-3012.01, 17-3012.02, 17-3013.00, 17-3012.01, 17-3012.02, 17-3013.00, 17-3012.01, 17-3012.02',\n",
+       "   'skills': '',\n",
+       "   'datePosted': '2016-03-17',\n",
+       "   'validThrough': None,\n",
+       "   'jobLocation': {'@type': 'Place',\n",
+       "    'address': {'@type': 'PostalAddress',\n",
+       "     'addressLocality': 'South Boston',\n",
+       "     'addressRegion': 'Virginia'}},\n",
+       "   'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "    'minValue': 0.0,\n",
+       "    'maxValue': 0.0,\n",
+       "    'medianValue': 0.0},\n",
+       "   'industry': '54',\n",
+       "   'onet_soc_code': '17-3013.00'},),\n",
+       " ({'@context': 'http://schema.org',\n",
+       "   '@type': 'JobPosting',\n",
+       "   'title': 'Driver Training School - City Driver',\n",
+       "   'description': 'General description of duties: This position involves attending an ABF freight approved driver training school. Upon proper completion of the program, attendees will perform the functions of a checker/driver combined Dock/P&D; Employee. QUALIFICATIONS: Minimum 21 years of age. Class A CDL permit, required. Be Able to obtain a class a CDL with doubles/triples, tanker and hazardous materials endorsements. Have a good stable work record. Have a safe driving record -LRB-from MVR and previous employment-RRB-. Be Able to pass Dot pre-employment drug screen and meet DOT medical requirements. BENEFITS: Equipment - preventive maintenance program for all ABF equipment. abf-cat-dts',\n",
+       "   'educationRequirements': '',\n",
+       "   'employmentType': '',\n",
+       "   'experienceRequirements': '',\n",
+       "   'incentiveCompensation': '',\n",
+       "   'qualifications': '',\n",
+       "   'occupationalCategory': '53-3022.00, 25-1194.00, 53-3032.02, 53-3022.00, 25-1194.00, 53-3032.00, 53-3022.00, 25-1194.00, 53-3032.00, 53-3022.00, 25-1194.00, 53-3032.00',\n",
+       "   'skills': '',\n",
+       "   'datePosted': '2016-03-17',\n",
+       "   'validThrough': None,\n",
+       "   'jobLocation': {'@type': 'Place',\n",
+       "    'address': {'@type': 'PostalAddress',\n",
+       "     'addressLocality': 'Richmond',\n",
+       "     'addressRegion': 'Virginia'}},\n",
+       "   'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "    'minValue': 0.0,\n",
+       "    'maxValue': 0.0,\n",
+       "    'medianValue': 0.0},\n",
+       "   'industry': '',\n",
+       "   'onet_soc_code': '53-3032.00'},),\n",
+       " ({'@context': 'http://schema.org',\n",
+       "   '@type': 'JobPosting',\n",
+       "   'title': 'Alliance Marketing Manager',\n",
+       "   'description': \"ABB needs an alliance marketing manager to Manage Business Development Activities for the alliance power transformer customers in the US market. Lead strategic planning for sales and orders at assigned accounts. Grow Alliance customers for power transformer North America through sales pursuits. Responsible for Alliance Steering Committee meetings, report cards, and customer alliance documentation. Provide customer and market feedback to business on current and future trends. Provide competitive pricing feedback. Typical duties/responsibilities for marketing may include, but are not limited to, the following: Account Planning: Work with front-end Sales -LRB-FES-RRB- account Mgrs. And key account VPS to develop alliance growth plans. Create target account supply strategy with FES and VP marketing. Ensure all target accounts have a viable account pursuit plan within order tracking systems -LRB-Ots-RRB-. Report progress on all target account plans quarterly. Managing and lead Alliance Steering Committee meetings. Support customer events. Forecast Alliance account volumes to affected factories. Tender design and support. Review Customer RFQ SPEC, and identify any issues that require follow-up with sales. For Must Win Opportunities; insure proposal is in line with must win strategy and goals. Set schedule and milestones for proposal. If schedule is outside customer's requirement follow-up with sales to request extension. Provide weights and final location to logistics. PROVIDE TERM & CONDITIONS TO SUPPLY UNIT. Pricing and quotation. Develop final pricing and packaging of all cost and data to complete bid. Manage: Risk Review, credit checks, bond requirements, insurance certificates, quality questionnaires,. Create customer final proposal using standard templates. Insure ABB's value is clearly communicated in customer terms. Quotation letter, and manage receipt of all appropriate approvals. Order negotiation and closing. Respond to commercial issues and customer clarifications via the business development manager. Contract review/order handoff. Call the meeting develops all contract documents and check lists for order hand off\",\n",
+       "   'educationRequirements': '',\n",
+       "   'employmentType': '',\n",
+       "   'experienceRequirements': '',\n",
+       "   'incentiveCompensation': '',\n",
+       "   'qualifications': '',\n",
+       "   'occupationalCategory': '11-2021.00, 11-2022.00, 19-3021.00, 11-2021.00, 11-2022.00, 19-3021.00, 11-2021.00, 11-2022.00, 13-1161.00, 11-2021.00, 11-2022.00, 13-1161.00',\n",
+       "   'skills': '',\n",
+       "   'datePosted': '2016-03-17',\n",
+       "   'validThrough': None,\n",
+       "   'jobLocation': {'@type': 'Place',\n",
+       "    'address': {'@type': 'PostalAddress',\n",
+       "     'addressLocality': 'South Boston',\n",
+       "     'addressRegion': 'Virginia'}},\n",
+       "   'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "    'minValue': 0.0,\n",
+       "    'maxValue': 0.0,\n",
+       "    'medianValue': 0.0},\n",
+       "   'industry': '54',\n",
+       "   'onet_soc_code': '11-2021.00'},),\n",
+       " ({'@context': 'http://schema.org',\n",
+       "   '@type': 'JobPosting',\n",
+       "   'title': 'Road Driver Full-Time',\n",
+       "   'description': 'GENERAL DESCRIPTION OF DUTIES: Road drivers are responsible for the pickup and delivery of cargo trailers to and from various long distance destinations. Responsibilities include but are not limited to: coupling and uncoupling trailers from one another and from the tractor, driving for an extended period of time, and performing various tasks ranging from check-in, tractor/trailer inspection, tractor set up and the pickup and delivery of cargo. Actual duties and schedule May vary depending on terminal location. QUALIFICATIONS: Minimum 21 years of age. Have 1 year of verifiable tractor/trailer experience -LRB-candidates with less than 1 year experience may be eligible for training-RRB-. Have a CLASS-A CDL with doubles/triples, tanker and hazardous materials endorsements. Have a good stable work record. Have a safe driving record -LRB-from MVR and previous employment-RRB-. Be Able to pass Dot pre-employment drug screen and meet DOT medical requirements. BENEFITS: road tractors average less than 18 months in age. Fully air-conditioned equipment. Tractors equipped with power steering. Preventive Maintenance Program for all ABF equipment. Wages - teamster union scale with over-the-road mileage rate. Retirement - provided through multi-employer pension fund. Excellent pension and health benefits for retirees. Life Insurance - provided through multi-employer sponsored health and Welfare Fund. Sick pay - 5 days per calendar year. Vacation - up to 5 weeks vacation for 30 years of service. 401K - company sponsored program. Medical - excellent medical, dental and vision coverage with no out-of-pocket premium cost to employees. ABF stock purchase plan. abf-cat-drv',\n",
+       "   'educationRequirements': '',\n",
+       "   'employmentType': '',\n",
+       "   'experienceRequirements': '',\n",
+       "   'incentiveCompensation': '',\n",
+       "   'qualifications': '',\n",
+       "   'occupationalCategory': '53-3032.02, 53-3032.00, 53-1031.00, 53-3032.00, 53-1031.00, 53-3031.00, 53-3032.00, 53-1031.00, 53-3031.00, 53-3032.00, 53-1031.00, 53-3031.00',\n",
+       "   'skills': '',\n",
+       "   'datePosted': '2016-03-17',\n",
+       "   'validThrough': None,\n",
+       "   'jobLocation': {'@type': 'Place',\n",
+       "    'address': {'@type': 'PostalAddress',\n",
+       "     'addressLocality': 'Wytheville',\n",
+       "     'addressRegion': 'Virginia'}},\n",
+       "   'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "    'minValue': 0.0,\n",
+       "    'maxValue': 0.0,\n",
+       "    'medianValue': 24000.0},\n",
+       "   'industry': '',\n",
+       "   'onet_soc_code': '53-7062.00'},)]"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "corpus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
    "outputs": [],
    "source": [
     "onet_soc_code = list(map(lambda c: c[0]['onet_soc_code'][:2], corpus))"
@@ -670,16 +804,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({'11': 78, '13': 22})"
+       "Counter({'15': 2, '41': 1, '53': 3, '': 1, '17': 2, '11': 1})"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -697,46 +831,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 69,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "job_postings_generator = JobPostingGenerator(\n",
-    "    s3_conn=s3_conn, \n",
-    "    quarters=['2011Q2'], \n",
-    "    s3_path='open-skills-private/test_corpus', \n",
-    "    source=\"all\"\n",
-    ")\n",
-    "corpus = CorpusCreator(job_postings_generator, filter_func=major_group_filter_func)"
+    "job_postings_generator = JobPostingCollectionSample()\n",
+    "filtered_job_postings = JobPostingFilterer(job_postings_generator, filter_funcs=[major_group_filter_func])\n",
+    "corpus = CorpusCreator(filtered_job_postings)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 71,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Eddie/Documents/DSSG/WDI/skills-ml/venv/lib/python3.5/site-packages/bs4/__init__.py:219: UserWarning: \"b'.'\" looks like a filename, not markup. You should probably open this file and pass the filehandle into Beautiful Soup.\n",
-      "  ' Beautiful Soup.' % markup)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "job_sampler = JobSampler(corpus, major_group=True,weights={'11': 1, '13': 3.5})\n",
-    "sampled_corpus = job_sampler.sample(50)"
+    "sampled_corpus = job_sampler.sample(10)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 72,
+   "metadata": {},
    "outputs": [],
    "source": [
     "major_group = list(map(lambda c: c[1][:2], sampled_corpus))"
@@ -744,16 +861,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Counter({'11': 23, '13': 27})"
+       "Counter({'11': 7, '13': 3})"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -764,7 +881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
@@ -772,26 +889,31 @@
       "text/plain": [
        "({'@context': 'http://schema.org',\n",
        "  '@type': 'JobPosting',\n",
-       "  'baseSalary': {'@type': 'MonetaryAmount', 'maxValue': '', 'minValue': ''},\n",
-       "  'datePosted': '2011-01-19',\n",
-       "  'description': 'Regional Staff Accountant Tracking Code 6466 Job Description Make your mark in Broadcasting and Digital Media. Sinclair Broadcast Group and Sinclair Digital Solutions are dedicated to making Sinclair a communications powerhouse! We are the largest and most diversified television broadcasting company in the country today. Sinclair owns and operates, programs or provides services to 162 stations located in 79 geographically diverse markets and our Digital group is focused on bringing the most engaging content to web, mobile and over-the-top broadcasting to audiences all over the country! Our success is the result of extraordinary employees and an exemplary management team who believe in a vision and are dedicated ensuring a great future for our employees. Whether you are an industry veteran or a just starting out, you can find it at Sinclair! We are advancing the world of Broadcasting and we want YOU to join our winning team! We are seeking a Regional Staff Accountant for our Business Operations hub, located in Portland, OR. The Regional Staff Accountant will report to the Regional Controller. Main duties will include supporting the business departments of assigned markets in the following areas: Job Duties: + Preparation of month end close, including financial statements and general ledger + Reconciliation of general ledger accounts + Fixed asset management + Budgeting and forecasting + Variance analysis + Human resources and payroll + Accounts receivable and credit management Requirements include: + Ability to work well in a fast-paced team environment + Ability to manage multiple tasks + High attention to detail + Strong accounting and analytical skills + Ability to meet multiple deadlines + Knowledge of SOX compliance + Proficiency in Microsoft Office products, especially Excel + Oracle experience preferred + Television broadcasting or media experience preferred + High attention to detail + Strong accounting and analytical skills + Ability to meet multiple deadlines Experience: + Knowledge of SOX compliance + Proficiency in Microsoft Office products, especially Excel Sinclair Broadcast Group, Inc. is proud to be an Equal Opportunity Employer and Drug Free Workplace! Job Location Portland, Oregon, United States Company Location KATU/KUNP Position Type Full-Time/Regular',\n",
+       "  'title': 'Site Support Lead',\n",
+       "  'description': \"Summary: Oversee site and act as the primary interface with customer on issues pertaining to NAS Oceana. Directs and coordinates site activities designed to ensure effective and economical support. Essential duties and responsibilities: Reports in writing and orally to AAR DSL management. Responding to on-site supply requirements generated by the squadron in support of C-40A organizational maintenance. Provides technical direction for specific projects assigned. Serves as a technical authority for various functional areas. Ensures tasks are completed within estimated time frames and budget constraints. Site responsibility for Fod program in totality. Inspects government provided on-site support under AAR custodial responsibility. Manager overall operations of the on-site storeroom. Selects most efficient means of transportation and shipping. Coordinate CFT -LRB-contract field team-RRB- personnel requirements and transportation, assembly and shipment of a CFT support kit. Schedules and assigns duties to direct reports. Attends daily US Navy stand up meetings to support all supply requirements. Attends all daily maintenance / material control meetings. Establishes all baseline minimum quantity levels. Prepares and approves appropriate training. Provides daily supervision and direction to staff to include scheduling. Provides all data required for the CDRL reports or additional meetings. Monitors each task and keeps AAR DSL leadership abreast of all problems and accomplishments. Anticipate problems related to operational areas and environmental and human factors, and then determine contingency requirements and solutions. Design and conduct research or technical studies to support functional areas. All other duties as assigned. Supervisory Responsibilites: carries out supervisory responsibilities in accordance with the organizations policies and applicable laws. Responsibilities include interviewing, hiring, and training employees; planning, assigning, and directing work; appraising performance; rewarding and disciplining employees; addressing complaints and resolving problems. To perform this job successfully, an individual must be able to perform each essential duty satisfactorily. The requirements listed are representative of the knowledge, skill, and/or ability required. Education and/or experience: Required: Bachelor of Arts degree -LRB-B.A.-RRB- or bachelor of science degree -LRB-B.S.-RRB- or bachelor of Business Administration -LRB-B.B.A.-RRB- from four-year college or university; or Ten -LRB-10-RRB- years' related experience. Eight -LRB-8-RRB- years' logistics experience, of which one -LRB-1-RRB- were in a direct supervisory role. Excellent oral and written communication skills. Proficient in MS office -LRB-word, Excel, access, powerpoint-RRB-. Must have the ability to obtain a common access card -LRB-CAC-RRB-. Desired: Experience in the aerospace/aviation industry is desired. Physical demands/working conditions: The physical demands and work environment characteristics described here are representative of those that must be met be an employee to successfully perform the essential functions of this job. Reasonable accommodations may be made to enable individuals with disabilities to perform the essential functions. While performing the duties of this job, the employee is regularly required to sit, stand, bend, reach, and move about the facility. Candidates should be able to adapt to a traditional business environment. In addition, this position requires the use of a computer, intermittent standing, walking, sitting, squatting, stretching, and bending throughout the workday. Must be able to see and hear, or use prosthetics that will enable these senses to function adequately to assure that the requirements of this position can be fully met. Job: OPERATIONS TITLE: Site Support Lead Location: VIRGINIA-VIRGINIA BEACH REQUISITION ID: 5398\",\n",
        "  'educationRequirements': '',\n",
+       "  'employmentType': '',\n",
        "  'experienceRequirements': '',\n",
-       "  'id': 'NLX_20797533',\n",
-       "  'industry': '',\n",
+       "  'incentiveCompensation': '',\n",
+       "  'qualifications': '',\n",
+       "  'occupationalCategory': '15-1041.00, 43-1011.02, 15-1071.00, 15-1041.00, 43-1011.00, 15-1071.00, 15-1151.00, 43-1011.00, 15-1142.00, 15-1151.00, 43-1011.00, 15-1142.00',\n",
+       "  'skills': '',\n",
+       "  'datePosted': '2016-03-17',\n",
+       "  'validThrough': None,\n",
        "  'jobLocation': {'@type': 'Place',\n",
        "   'address': {'@type': 'PostalAddress',\n",
-       "    'addressLocality': 'Portland',\n",
-       "    'addressRegion': 'OR'}},\n",
-       "  'numPositions': '',\n",
-       "  'onet_soc_code': '13-2011.01',\n",
-       "  'qualifications': '',\n",
-       "  'skills': '',\n",
-       "  'title': 'Regional Staff Accountant'},\n",
-       " '13')"
+       "    'addressLocality': 'Virginia Beach',\n",
+       "    'addressRegion': 'Virginia'}},\n",
+       "  'baseSalary': {'@type': 'MonetaryAmount',\n",
+       "   'minValue': 0.0,\n",
+       "   'maxValue': 0.0,\n",
+       "   'medianValue': 68000.0},\n",
+       "  'industry': '33',\n",
+       "  'onet_soc_code': '11-1021.00'},\n",
+       " '11')"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -799,15 +921,6 @@
    "source": [
     "sampled_corpus[0]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -826,7 +939,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/skills_ml/job_postings/common_schema.py
+++ b/skills_ml/job_postings/common_schema.py
@@ -12,9 +12,10 @@ from skills_utils.s3 import log_download_progress
 from skills_ml.job_postings.raw.virginia import VirginiaTransformer
 
 import json
+import os
 import gzip
 
-from typing import Dict, Text, Any, Generator, List
+from typing import Dict, Text, Any, Generator, List, Callable
 
 JobPostingType = Dict[Text, Any]
 JobPostingGeneratorType = Generator[JobPostingType, None, None]
@@ -81,7 +82,8 @@ class JobPostingCollectionSample(object):
         if num_records > 50:
             logging.warning('Cannot provide %s records as a maximum of 50 are available', num_records)
             num_records = 50
-        f = gzip.GzipFile(filename='50_sample.json.gz')
+        full_filename = os.path.join(os.path.dirname(__file__), '../../50_sample.json.gz')
+        f = gzip.GzipFile(filename=full_filename)
         self.lines = f.read().decode('utf-8').split('\n')[0:num_records]
         self.transformer = VirginiaTransformer(partner_id='VA')
 

--- a/skills_ml/job_postings/filtering.py
+++ b/skills_ml/job_postings/filtering.py
@@ -1,0 +1,45 @@
+"""Filtering streamed job postings"""
+
+from .common_schema import JobPostingType, JobPostingGeneratorType, MetadataType
+
+from typing import Callable, List
+
+
+def soc_major_group_filter(major_groups: List) -> Callable:
+    """Return a function that checks the ONET Soc Code of a job posting (if it is present) against the configured major groups.
+    """
+    def job_posting_is_in_major_group(document: JobPostingType) -> bool:
+        key = 'onet_soc_code'
+        if not document[key]:
+            return False
+        if document[key][:2] not in major_groups:
+            return False
+        return True
+    return job_posting_is_in_major_group
+
+
+class JobPostingFilterer(object):
+    """Filter common schema job postings through a number of filtering functions
+
+    Args:
+        job_posting_generator: An iterable of job postings (each in dict form)
+        filter_funcs: A list of filtering functions, each taking in a job posting document (as dict) and returning a boolean instructing whether or not the posting passes the filter
+    """
+    def __init__(
+        self,
+        job_posting_generator: JobPostingGeneratorType,
+        filter_funcs: List[Callable]
+    ):
+        self.job_posting_generator = job_posting_generator
+        self.filter_funcs = filter_funcs
+
+    def __iter__(self) -> JobPostingGeneratorType:
+        """Yield all job postings in the configured generator that pass all configured filtering functions"""
+        for job_posting in self.job_posting_generator:
+            can_yield = all(filter_func(job_posting) for filter_func in self.filter_funcs)
+            if can_yield:
+                yield job_posting
+
+    @property
+    def metadata(self) -> MetadataType:
+        return {'job_posting_filters': ':'.join(str(func) for func in self.filter_funcs)}


### PR DESCRIPTION
The CorpusCreator had gotten too big, and the filtering functionality had to go. Introducing skills_ml.job_postings.filtering, which implements this functionality. The JobPostingFilterer both takes in and produces a generator of JobPostings, so it can be used wherever a JobPostingGenerator can be used.