### PR TITLE
Refactoring Occupation Classifier

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include 50_sample.json.gz
 include README.md
 include LICENSE.md
 include tests/*.py
+include sample_job_listing.json
+recursive-include requirement *.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include 50_sample.json.gz
 include README.md
+include LICENSE.md
+include tests/*.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include README.md
 include LICENSE.md
 include tests/*.py
 include sample_job_listing.json
-recursive-include requirement *.txt
+recursive-include requirements*.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include README.md
 include LICENSE.md
 include tests/*.py
 include sample_job_listing.json
-recursive-include requirements*.txt
+include requirements.txt
+include requirements_dev.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include 50_sample.json.gz
+include README.md

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
     python:
-        version: 3.6
+        version: 3.6.3

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+    python:
+        version: 3.6.4

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
     python:
-        version: 3.6.4
+        version: 3.6

--- a/skills_ml/algorithms/embedding/models.py
+++ b/skills_ml/algorithms/embedding/models.py
@@ -25,7 +25,7 @@ class Word2VecModel(ModelStorage, Word2Vec):
         """
         ModelStorage.__init__(self, storage=kwargs.pop('storage', None))
         Word2Vec.__init__(self, *args, **kwargs)
-        self.model_name = None
+        self.model_name = ""
         self._metadata = None
 
     def infer_vector(self, doc_words):
@@ -68,5 +68,5 @@ class Doc2VecModel(ModelStorage, Doc2Vec):
         """
         ModelStorage.__init__(self, storage=kwargs.pop('storage', None))
         Doc2Vec.__init__(self, *args, **kwargs)
-        self.model_name = None
+        self.model_name = ""
         self.lookup_dict = None

--- a/skills_ml/algorithms/embedding/train.py
+++ b/skills_ml/algorithms/embedding/train.py
@@ -114,9 +114,9 @@ class EmbeddingTrainer(object):
 
     @property
     def model_type(self):
-        if self.corpus_generator.__class__.__name__ == 'Doc2VecGensimCorpusCreator':
+        if self._model.__class__.__name__ == 'Doc2VecModel':
             return 'doc2vec'
-        elif self.corpus_generator.__class__.__name__ == 'Word2VecGensimCorpusCreator':
+        elif self._model.__class__.__name__ == 'Word2VecModel':
             return 'word2vec'
 
     @property
@@ -153,5 +153,9 @@ class EmbeddingTrainer(object):
         else:
             print("Haven't trained the model yet!")
 
-        meta_dict.update(self.corpus_generator.metadata)
+        try:
+            meta_dict.update(self.corpus_generator.metadata)
+        except AttributeError:
+            logging.info(self.corpus_generator.__class__.__name__ + " has no metadata!")
+
         return meta_dict

--- a/skills_ml/algorithms/occupation_classifiers/classifiers.py
+++ b/skills_ml/algorithms/occupation_classifiers/classifiers.py
@@ -1,141 +1,86 @@
-import tempfile
-import os
-import logging
-from collections import Counter, defaultdict
-import filelock
+from skills_ml.algorithms.embedding.base import ModelStorage
+from skills_ml.algorithms.embedding.models import Doc2VecModel
 
 from gensim.similarities.index import AnnoyIndexer
 
-from skills_ml.algorithms.embedding import models
-from skills_utils.s3 import download, split_s3_path, list_files
+import logging
+from collections import Counter, defaultdict
+import pickle
 
 
-def download_ann_classifier_files(s3_prefix, classifier_id, download_directory, s3_conn):
-    lock = filelock.FileLock(os.path.join(download_directory, 'ann_dl.lock'))
-    with lock.acquire(timeout=1000):
-        s3_path = s3_prefix + classifier_id
-        files = list_files(s3_conn, s3_path)
-        for f in files:
-            filepath = os.path.join(download_directory, f)
-            if not os.path.exists(filepath):
-                logging.info('calling download from %s to %s', s3_path + f, filepath)
-                download(s3_conn, filepath, os.path.join(s3_path, f))
-            else:
-                logging.info('%s already exists, not downloading', filepath)
-
-
-class Classifier(object):
-    """The Classifiers Object to classify each jobposting description to O*Net SOC code.
-
-    Example:
-
-    from airflow.hooks import S3Hook
-    from skills_ml.algorithms.occupation_classifiers.classifiers import Classifier
-
-    s3_conn = S3Hook().get_conn()
-    Soc = Classifier(s3_conn=s3_conn, classifier_id='ann_0614')
-
-    predicted_soc = Soc.classify(jobposting, mode='top')
-    """
-    def __init__(self, classifier_id='ann_0614', classifier=None,
-        s3_conn=None, s3_path='open-skills-private/model_cache/occupation_classifiers/', classify_kwargs=None, temporary_directory=None, **kwargs):
-        """Initialization of Classifier
-
-        Attributes:
-            classifier_id (str): classifier id
-            classifier_type (str): classifier type
-            s3_path (str): the path of the classifier on S3.
-            s3_conn (:obj: `boto.s3.connection.S3Connection`): the boto object to connect to S3.
-            files (:obj: `list` of (str)): classifier files need to be downloaded/loaded.
-            classifier (:obj): classifier object that will do the actually classification
-            classify_kwargs (:dict): arguments to pass through to the .classify method when called on a job posting
-        """
-        self.classifier_id = classifier_id
-        self.classifier_type = classifier_id.split('_')[0]
-        self.s3_conn = s3_conn
-        self.s3_path = s3_path + classifier_id
-        self.temporary_directory = temporary_directory or tempfile.TemporaryDirectory()
-        self.classifier = self._load_classifier(**kwargs) if classifier == None else classifier
-        self.classify_kwargs = classify_kwargs if classify_kwargs else {}
-
-    def _load_classifier(self, **kwargs):
-        if self.classifier_type == 'ann':
-            for f in list_files(self.s3_conn, self.s3_path):
-                filepath = os.path.join(self.temporary_directory, f)
-                if not os.path.exists(filepath):
-                    logging.warning('calling download from %s to %s', self.s3_path + f, filepath)
-                    download(self.s3_conn, filepath, os.path.join(self.s3_path, f))
-            ann_index = AnnoyIndexer()
-            ann_index.load(os.path.join(self.temporary_directory, self.classifier_id + '.index'))
-            return NearestNeighbors(s3_conn=self.s3_conn, indexer=ann_index, **kwargs)
-
-        elif self.classifier_type == 'knn':
-            return NearestNeighbors(s3_conn=self.s3_conn, indexed=False, **kwargs)
-
-        else:
-            print('Not implemented yet!')
-            return None
-
-    def classify(self, jobposting):
-        return self.classifier.predict_soc(jobposting, **(self.classify_kwargs))
-
-
-class NearestNeighbors(models.Doc2VecModel):
+class KNNDoc2VecClassifier(ModelStorage):
     """Nearest neightbors model to classify the jobposting data into soc code.
     If the indexer is passed, then NearestNeighbors will use approximate nearest
     neighbor approach which is much faster than the built-in knn in gensim.
 
     Attributes:
-        indexed (bool): index the data with Annoy or not. Annoy can find approximate nearest neighbors much faster.
-        indexer (:obj: `gensim.similarities.index`): Annoy index object should be passed in for faster query.
+        embedding_model (:job: `skills_ml.algorithms.embedding.models.Doc2VecModel`): Doc2Vec embedding model
+        indexer (:obj: `gensim.similarities.index`): any kind of gensim compatible indexer
     """
-    def __init__(self, indexed=False, indexer=None, **kwargs):
-        super(NearestNeighbors, self).__init__(**kwargs)
-        self.indexed = indexed
-        self.indexer = self._ann_indexer() if indexed else indexer
+    def __init__(self, embedding_model, indexer=None, **kwargs):
+        if not isinstance(embedding_model, Doc2VecModel):
+            raise NotImplementedError("Only support doc2vec now.")
 
+        super().__init__(storage=kwargs.pop('storage', embedding_model._storage))
+        self.model = embedding_model
+        self.model_name = "knn_cls_" + self.model.model_name
+        self.indexer = indexer
 
-    def _ann_indexer(self):
-        """This function should be in the training process. It's here for temporary usage.
-        Annoy is an open source library to search for points in space that are close to a given query point.
+    def build_ann_indexer(self, num_trees=100):
+        """ Annoy is an open source library to search for points in space that are close to a given query point.
         It also creates large read-only file-based data structures that are mmapped into memory so that many
         processes may share the same data. For our purpose, it is used to find similarity between words or
         documents in a vector space.
 
         Returns:
-            Annoy index object if self.indexed is True. None if we want to use gensim built-in index.
+            Annoy index object
         """
 
         logging.info('indexing the model %s', self.model_name)
         self.model.init_sims()
-        annoy_index = AnnoyIndexer(self.model, 200)
+        annoy_index = AnnoyIndexer(self.model, num_trees)
+        self.indexer = annoy_index
         return annoy_index
 
-
-    def predict_soc(self, jobposting, mode='top'):
+    def predict_soc(self, tokenized_list, k=1):
         """The method to predict the soc code a job posting belongs to.
 
         Args:
-            jobposting (str): a string of cleaned, lower-cased and pre-processed job description context.
-            mode (str): a flag of which method to use for classifying.
+            tokenized_list (list): a list of words of tokenized string
+            k (int): If k = 1, look for the soc code from single nearest neighbor. If k > 1, classify the soc code by
+            a majority vote of nearest k neighbor.
 
         Returns:
             tuple(str, float): The predicted soc code and cosine similarity.
         """
-        inferred_vector = self.model.infer_vector(jobposting.split())
-        if mode == 'top':
+        inferred_vector = self.model.infer_vector(tokenized_list)
+        if k == 1:
             sims = self.model.docvecs.most_similar([inferred_vector], topn=1, indexer=self.indexer)
-            resultlist = list(map(lambda l: (self.lookup[l[0]], l[1]), [(x[0], x[1]) for x in sims]))
+            resultlist = list(map(lambda l: (self.model.lookup_dict[l[0]], l[1]), [(x[0], x[1]) for x in sims]))
             predicted_soc = resultlist[0]
-            return predicted_soc
-
-        if mode == 'common':
-            sims = self.model.docvecs.most_similar([inferred_vector], topn=10, indexer=self.indexer)
-            resultlist = list(map(lambda l: (self.lookup[l[0]], l[1]), [(x[0], x[1]) for x in sims]))
+        elif k > 1:
+            sims = self.model.docvecs.most_similar([inferred_vector], topn=k, indexer=self.indexer)
+            resultlist = list(map(lambda l: (self.model.lookup_dict[l[0]], l[1]), [(x[0], x[1]) for x in sims]))
             most_common = Counter([r[0] for r in resultlist]).most_common()[0]
             resultdict = defaultdict(list)
-            for k, v in resultlist:
-                resultdict[k].append(v)
-
+            for u, v in resultlist:
+                resultdict[u].append(v)
             predicted_soc = (most_common[0], sum(resultdict[most_common[0]])/most_common[1])
-            return predicted_soc
+        else:
+            raise ValueError("k should not be smaller than 1!")
+
+        return predicted_soc
+
+    def save(self, model_name=None):
+        """The method to write the model to where the Storage object specified
+
+        model_name (str): name of the model to be used.
+        """
+        tmp_annoy_index = self.indexer
+        self.indexer = None
+        if model_name is None:
+            model_name = self.model_name
+
+        model_pickled = pickle.dumps(self)
+        self.storage.write(model_pickled, model_name)
+        self.indexer = tmp_annoy_index

--- a/skills_ml/job_postings/computed_properties/computers.py
+++ b/skills_ml/job_postings/computed_properties/computers.py
@@ -92,13 +92,13 @@ class SOCClassifyProperty(JobPostingComputedProperty):
         classifier_obj (object, optional) An object to use as a classifier.
             If not sent one will be downloaded from s3
     """
-    def __init__(self, classifier_obj=None, *args, **kwargs):
+    def __init__(self, classifier_obj, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.classifier_obj = classifier_obj
+        self.classifier = SocClassifier(classifier_obj)
 
     def _compute_func_on_one(self):
 
-        common_classifier = SocClassifier(self.classifier_obj)
+        common_classifier = self.classifier
         corpus_creator = SimpleCorpusCreator()
 
         def func(job_posting):
@@ -106,33 +106,26 @@ class SOCClassifyProperty(JobPostingComputedProperty):
 
         return func
 
+    @property
+    def property_name(self):
+        return self.classifier.name
 
-class ClassifyCommon(SOCClassifyProperty):
-    """Classify SOC code using common match method"""
-    property_name = 'soc_common'
-    property_columns = [
-        ComputedPropertyColumn(
-            name='soc_common',
-            description='SOC code inferred by common match method',
-            compatible_aggregate_function_paths={
-                'skills_ml.job_postings.aggregate.pandas.n_most_common': 'Most common'
-            }
-        )
-    ]
+    @property
+    def property_description(self):
+        return self.classifier.description
 
-
-class ClassifyTop(SOCClassifyProperty):
-    """Classify SOC code using top match method"""
-    property_name = 'soc_top'
-    property_columns = [
-        ComputedPropertyColumn(
-            name='soc_top',
-            description='SOC code inferred by top match method',
-            compatible_aggregate_function_paths={
-                'skills_ml.job_postings.aggregate.pandas.n_most_common': 'Most common'
-            }
-        )
-    ]
+    @property
+    def property_columns(self):
+        property_columns = [
+            ComputedPropertyColumn(
+                name=self.property_name,
+                description=self.property_description,
+                compatible_aggregate_function_paths={
+                    'skills_ml.job_postings.aggregate.pandas.n_most_common': 'Most common'
+                }
+            )
+        ]
+        return property_columns
 
 
 class GivenSOC(JobPostingComputedProperty):

--- a/tests/algorithms/test_occupation_classifiers.py
+++ b/tests/algorithms/test_occupation_classifiers.py
@@ -77,7 +77,7 @@ class TestKNNDoc2VecClassifier(unittest.TestCase):
             # KNNDoc2VecClassifier only supports doc2vec now
             self.assertRaises(NotImplementedError, lambda: KNNDoc2VecClassifier(Word2VecModel()))
 
-            doc = docs.split(',')[0]
+            doc = docs.split(',')[0].split()
 
             knn = KNNDoc2VecClassifier(embedding_model=d2v, k=0)
             self.assertRaises(ValueError, lambda: knn.predict_soc(doc))
@@ -121,7 +121,7 @@ class TestKNNDoc2VecClassifier(unittest.TestCase):
         # KNNDoc2VecClassifier only supports doc2vec now
         self.assertRaises(NotImplementedError, lambda: KNNDoc2VecClassifier(Word2VecModel()))
 
-        doc = docs.split(',')[0]
+        doc = docs.split(',')[0].split()
 
         knn = KNNDoc2VecClassifier(embedding_model=d2v, k=0)
         self.assertRaises(ValueError, lambda: knn.predict_soc(doc))

--- a/tests/algorithms/test_train_embedding.py
+++ b/tests/algorithms/test_train_embedding.py
@@ -27,7 +27,6 @@ class TestTrainEmbedding(unittest.TestCase):
         s3_storage = S3Store(path=s3_path)
 
         document_schema_fields = ['description','experienceRequirements', 'qualifications', 'skills']
-        document_schema_fields = ['description','experienceRequirements', 'qualifications', 'skills']
         job_postings_generator = JobPostingCollectionSample(num_records=30)
         corpus_generator = Doc2VecGensimCorpusCreator(job_postings_generator, document_schema_fields=document_schema_fields)
         d2v = Doc2VecModel(storage=s3_storage, size=10, min_count=3, iter=4, window=6, workers=3)

--- a/tests/job_postings/test_computed_properties.py
+++ b/tests/job_postings/test_computed_properties.py
@@ -15,7 +15,7 @@ from skills_ml.job_postings.computed_properties.computers import (
     TitleCleanPhaseOne,
     TitleCleanPhaseTwo,
     CBSAandStateFromGeocode,
-    ClassifyTop,
+    SOCClassifyProperty,
     ExactMatchSkillCounts
 )
 
@@ -161,7 +161,15 @@ class SocClassifyWithFakeClassifierTest(ComputedPropertyTestCase):
                 assert document.strip() == description.lower()
                 return '11-1234.00'
 
-        self.computed_property = ClassifyTop(
+            @property
+            def name(self):
+                return "MockClassifier"
+
+            @property
+            def description(self):
+                return "fake algorithm"
+
+        self.computed_property = SOCClassifyProperty(
             storage=storage,
             classifier_obj=MockClassifier(),
         )
@@ -173,6 +181,9 @@ class SocClassifyWithFakeClassifierTest(ComputedPropertyTestCase):
         job_posting_id = self.job_postings[0]['id']
         assert cache[job_posting_id] == '11-1234.00'
 
+    def test_name_description(self):
+        assert self.computed_property.property_name == "soc_mock_classifier"
+        assert self.computed_property.property_description == "SOC code classifier using fake algorithm"
 
 @mock_s3
 @mock_s3_deprecated


### PR DESCRIPTION
- Removed s3 dependency from occupation dependency. Now skill-ml should be free from s3 dependency. 
- Add `SocClassifier` as an interface for `SOCClassifyProperty` or other `computers` classes to use.
- `KNNDoc2VecClassifier` is a simple KNN classifier by directly querying from training doc vectors. Ones can feed it's own indexer or call `build_ann_indexer()` which will build a Approximate Nearest Neighbor index (https://github.com/spotify/annoy). Noted that the indexer won't be saved when we call `KNNDoc2VecClassifier().save()`. Only the object itself will be saved. So we might want to build the ann index every time we load the classifier.