### PR TITLE
CompetencyOntology and related classes [Resolves #186]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ notifications:
   slack:
     secure: b7XBAtsHLlROoqR0P1z3phK9LHTB5SzOvS8VRk9nYzqrOGZ749IGEzBSZc1s6SzXQ701wgXZ9TZ+wSn46uO/+PiNiol27lu13O76JoMz+idFyb07lW7wltE/4mlWyYm87f7cLKaaxr3+2+Wr7VDJsvWvnIyZDCN16HrKE2h0JdnLTjsC8pXPDmFGA5ZDuQg0l/D7n4+AV+4OoUt2UQzyHoOROyoEjYV6OejEkWwQeJ5FY/2FCgYJZud4U+FVXkcjrlPBYFA+IevgBPu5LOwJjjIAq2C5E6F287VpvYoPnAdKA8IW0kR6FRW9CD5s5YpTf5BbEz/UMfUOChj0r7cSjwk+/RooqJ6nDK2t9gqpx8m+SZUO2JoZo/if/4yE8UIZD2WjhT/CIK34YS6aZDjj+7MoYYtBO87uf2cWV7gkDTg3v+aVf9IgQ4o6IU4YvGQCkTF6vZ9hn0BkTwZyjoKNc/+eWsKB69CwAXkxww8bXYHLCDCjjCejAhc9TtHiY06bHalTny40DPTwKLwlNjrDz8KQOjMtvF5eoF5h74lvTyYmG88LDvY9HZFVYhBOh8dZ68y2GRG9TlwGPXq4lRNLMcW9KCPC7Fg9N3pgI4ChXuKWQ2fQH700SEq76VrHEMYhv6sxbG6KXt4sdeEaD3wHlrzh02C7NKqelwIbw0AQKng=
 python: 3.6
-script: py.test -vvv -s --cov=skills_ml.algorithms --cov=skills_ml.datasets --cov=skills_ml.evaluation --cov=skills_ml.job_postings
+script: py.test -vvv -s --cov=skills_ml.algorithms --cov=skills_ml.datasets --cov=skills_ml.evaluation --cov=skills_ml.job_postings --cov=skills_ml.ontologies

--- a/docs/pydocmd.yml
+++ b/docs/pydocmd.yml
@@ -40,6 +40,7 @@ markdown_extensions:
 pages:
 - {Home: index.md << ../README.md}
 - {Examples: examples.md}
+- {Ontology Class: ontologies.md}
 - {Job Posting Common Schema: common_schema.md}
 - {Evaluation Tools: skills_ml.evaluation.md}
 - {Algorithms: skills_ml.algorithms.md}

--- a/skills_ml/datasets/onet_source.py
+++ b/skills_ml/datasets/onet_source.py
@@ -4,6 +4,7 @@ import os
 import logging
 import io
 import zipfile
+import csv
 
 
 class OnetToMemoryDownloader(object):

--- a/skills_ml/ontologies/__init__.py
+++ b/skills_ml/ontologies/__init__.py
@@ -1,0 +1,8 @@
+from .base import Competency, Occupation, CompetencyOccupationEdge, CompetencyOntology
+
+__all__ = (
+    'Competency',
+    'Occupation',
+    'CompetencyOccupationEdge',
+    'CompetencyOntology'
+)

--- a/skills_ml/ontologies/base.py
+++ b/skills_ml/ontologies/base.py
@@ -1,0 +1,323 @@
+from typing import Callable, Text
+import json
+
+
+class Competency(object):
+    """Represents a competency not necessarily tied to an ontology
+
+    Args:
+        identifier: A unique identifier for this competency. Choose the identifier wisely as it will be used for equivalence with other competency objects
+        name: A name for the competency (e.g. Microsoft Office)
+        category: An optional text category for the competency that is not a higher-level competency itself
+    """
+
+    def __init__(self, identifier: Text, name: Text=None, category: Text=None, **kwargs):
+        self.identifier = identifier
+        self.name = name or ''
+        self.category = category
+        self.other_attributes = kwargs
+        self.children = set()
+        self.parents = set()
+
+    @classmethod
+    def from_jsonld(cls, jsonld_input):
+        extra_kwargs = dict((key, jsonld_input[key]) for key in jsonld_input.keys() if key not in {'@type', '@id', 'name', 'competencyCategory', 'hasChild', 'isChildOf'})
+        obj = cls(
+            identifier=jsonld_input['@id'],
+            name=jsonld_input.get('name', ''),
+            category=jsonld_input.get('competencyCategory', None),
+            **extra_kwargs
+        )
+        for jsonld_child_obj in jsonld_input.get('hasChild', []):
+            obj.add_child(cls(identifier=jsonld_child_obj['@id']))
+        for jsonld_parent_obj in jsonld_input.get('isChildOf', []):
+            obj.add_parent(cls(identifier=jsonld_parent_obj['@id']))
+        return obj
+
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return self.identifier == other.identifier
+
+    def __hash__(self):
+        return hash(self.identifier)
+
+    def __repr__(self):
+        return f'Competency(identifier={self.identifier}, name={self.name}, category={self.category}, {self.other_attributes})'
+
+    @property
+    def jsonld_id(self):
+        return {
+            '@type': 'Competency',
+            '@id': self.identifier
+        }
+
+    @property
+    def jsonld_full(self):
+        attributes = {
+            '@type': 'Competency',
+            '@id': self.identifier,
+            'name': self.name,
+            'competencyCategory': self.category,
+            'hasChild': [child.jsonld_id for child in self.children],
+            'isChildOf': [parent.jsonld_id for parent in self.parents],
+        }
+        for key, value in self.other_attributes.items():
+            attributes[key] = value
+        return attributes
+
+    def add_child(self, child):
+        if not isinstance(child, Competency):
+            raise ValueError('All children of a Competency must be Competencies themselves')
+        if child not in self.children:
+            self.children.add(child)
+            child.add_parent(self)
+
+    def add_parent(self, parent):
+        if not isinstance(parent, Competency):
+            raise ValueError('All parents of a Competency must be Competencies themselves')
+        if parent not in self.parents:
+            self.parents.add(parent)
+            parent.add_child(self)
+
+
+class Occupation(object):
+    """Represents an occupation that may or may not be part of an ontology
+    
+    Args:
+        identifier: A unique identifier for this occupation. Choose the identifier wisely as it will be used for equivalence with other occupation objects
+        name: A name for the occupation (e.g. Civil Engineer)
+    """
+
+    def __init__(self, identifier, name=None, **kwargs):
+        self.identifier = identifier
+        self.name = name or ''
+        self.other_attributes = kwargs
+        self.children = set()
+        self.parents = set()
+
+    @classmethod
+    def from_jsonld(cls, jsonld_input):
+        extra_kwargs = dict((key, jsonld_input[key]) for key in jsonld_input.keys() if key not in {'@type', '@id', 'name', 'hasChild', 'isChildOf'})
+        obj = cls(
+            identifier=jsonld_input['@id'],
+            name=jsonld_input.get('name', ''),
+            **extra_kwargs
+        )
+        for jsonld_child_obj in jsonld_input.get('hasChild', []):
+            obj.add_child(cls(identifier=jsonld_child_obj['@id']))
+        for jsonld_parent_obj in jsonld_input.get('isChildOf', []):
+            obj.add_parent(cls(identifier=jsonld_parent_obj['@id']))
+        return obj
+
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return self.identifier == other.identifier
+
+    def __hash__(self):
+        return hash(self.identifier)
+
+    def __repr__(self):
+        return f'Occupation(identifier={self.identifier}, name={self.name}, {self.other_attributes})'
+
+    @property
+    def jsonld_id(self):
+        return {
+            '@type': 'Occupation',
+            '@id': self.identifier
+        }
+
+    @property
+    def jsonld_full(self):
+        attributes = {
+            '@type': 'Occupation',
+            '@id': self.identifier,
+            'name': self.name,
+            'hasChild': [child.jsonld_id for child in self.children],
+            'isChildOf': [parent.jsonld_id for parent in self.parents],
+        }
+        for key, value in self.other_attributes.items():
+            attributes[key] = value
+        return attributes
+
+
+    def add_child(self, child):
+        if not isinstance(child, Occupation):
+            raise ValueError('All children of a Occupation must be Occupations themselves')
+        if child not in self.children:
+            self.children.add(child)
+            child.add_parent(self)
+
+    def add_parent(self, parent):
+        if not isinstance(parent, Occupation):
+            raise ValueError('All parents of a Occupation must be Occupations themselves')
+        if parent not in self.parents:
+            self.parents.add(parent)
+            parent.add_child(self)
+
+
+class DummyOccupation(Occupation):
+    def __init__(self):
+        super().__init__('0', '')
+
+class DummyCompetency(Competency):
+    def __init__(self):
+        super().__init__('0', '')
+
+
+class CompetencyOccupationEdge(object):
+    def __init__(self, competency, occupation, identifier=None):
+        self.competency = competency
+        self.occupation = occupation
+        self.identifier = f'competency={competency.identifier}&occupation={occupation.identifier}'
+        if identifier:
+            assert identifier == self.identifier
+
+    def __repr__(self):
+        return f'CompetencyOccupationEdge(competency={self.competency}, occupation={self.occupation})'
+
+    @classmethod
+    def from_jsonld(cls, jsonld_input):
+        obj = cls(
+            identifier=jsonld_input['@id'],
+            competency=Competency.from_jsonld(jsonld_input['competency']),
+            occupation=Occupation.from_jsonld(jsonld_input['occupation'])
+        )
+        return obj
+
+    @property
+    def jsonld_id(self):
+        return {
+            '@type': 'CompetencyOccupationEdge',
+            '@id': self.identifier
+        }
+
+    @property
+    def jsonld_full(self):
+        return {
+            '@type': 'CompetencyOccupationEdge',
+            '@id': self.identifier,
+            'competency': self.competency.jsonld_id,
+            'occupation': self.occupation.jsonld_id
+        }
+
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return self.competency == other.competency\
+                and self.occupation == other.occupation
+
+    def __hash__(self):
+        return hash(self.competency) + hash(self.occupation)
+
+
+class CompetencyOntology(object):
+    """An ontology of competencies and occupations and the edges between them
+    
+    Can be initialized with a set of edges, in which case the competencies and occupations will be initialized with any that are present in the edge list
+    """
+    def __init__(self, edges=None):
+        if edges:
+            self._competency_occupation_edges = edges
+            self._competencies = dict((edge.competency.identifier, edge.competency) for edge in edges)
+            self._occupations = dict((edge.occupation.identifier, edge.occupation) for edge in edges)
+        else:
+            self._competencies = dict()
+            self._occupations = dict()
+            self._competency_occupation_edges = set()
+
+    @classmethod
+    def from_jsonld(cls, jsonld_string: Text):
+        jsonld_input = json.loads(jsonld_string)
+        obj = cls()
+        for competency_jsonld in jsonld_input['competencies']:
+            obj.add_competency(Competency.from_jsonld(competency_jsonld))
+        for occupation_jsonld in jsonld_input['occupations']:
+            obj.add_occupation(Occupation.from_jsonld(occupation_jsonld))
+        for edge_jsonld in jsonld_input['edges']:
+            obj.add_edge(edge=CompetencyOccupationEdge.from_jsonld(edge_jsonld))
+
+        return obj
+        
+    def __eq__(self, other):
+        if isinstance(self, other.__class__):
+            return \
+                self.competencies == other.competencies \
+                and self.occupations == other.occupations \
+                and self.edges == other.edges
+
+
+    def __str__(self):
+        return f'Competency Framework with {len(self.competencies)} competencies' + \
+            f', {len(self.occupations)} occupations' + \
+            f', {len(self.edges)} competency-occupation edges'
+
+    @property
+    def competencies(self):
+        return set(self._competencies.values()) - {DummyCompetency()}
+
+    @property
+    def occupations(self):
+        return set(self._occupations.values()) - {DummyOccupation()}
+
+    @property
+    def edges(self):
+        values = set([
+            edge for edge in self._competency_occupation_edges
+            if edge.occupation != DummyOccupation() and edge.competency != DummyCompetency()
+        ])
+        return values
+
+    def add_competency(self, competency: Competency):
+        if not isinstance(competency, Competency):
+            raise ValueError('Must add competency objects')
+        if competency.identifier not in self._competencies:
+            self._competencies[competency.identifier] = competency
+            self.add_edge(competency=competency, occupation=DummyOccupation())
+
+    def add_occupation(self, occupation: Occupation):
+        if not isinstance(occupation, Occupation):
+            raise ValueError('Must add occupation objects')
+        if occupation.identifier not in self._occupations:
+            self._occupations[occupation.identifier] = occupation
+            self.add_edge(competency=DummyCompetency(), occupation=occupation)
+
+    def add_edge(self, occupation: Occupation=None, competency: Competency=None, edge: CompetencyOccupationEdge=None):
+        if edge:
+            self._competency_occupation_edges.add(edge)
+            return
+
+        if not isinstance(occupation, Occupation) or not isinstance(competency, Competency):
+            raise ValueError('Must pass both an occupation and competency')
+        self.add_competency(competency)
+        self.add_occupation(occupation)
+        edge = CompetencyOccupationEdge(
+            occupation=self._occupations[occupation.identifier],
+            competency=self._competencies[competency.identifier]
+        )
+        if edge not in self._competency_occupation_edges:
+            self._competency_occupation_edges.add(edge)
+
+    def filter_by(self, func: Callable):
+        """Produce an ontology that is filtered by a callable that takes in an edge
+        """
+        matching_edges = set(edge for edge in self._competency_occupation_edges if func(edge))
+        return CompetencyOntology(edges=matching_edges)
+
+    @property
+    def jsonld(self):
+        return json.dumps({
+            'competencies': [
+                competency.jsonld_full
+                for competency in
+                sorted(self.competencies, key=lambda competency: competency.identifier)
+            ],
+            'occupations': [
+                occupation.jsonld_full
+                for occupation in
+                sorted(self.occupations, key=lambda occupation: occupation.identifier)
+            ],
+            'edges': [
+                edge.jsonld_full
+                for edge in
+                sorted(self.edges, key=lambda edge: edge.identifier)
+            ]
+        }, sort_keys=True)

--- a/skills_ml/ontologies/base.py
+++ b/skills_ml/ontologies/base.py
@@ -1,4 +1,4 @@
-from typing import Callable, Text
+from typing import Callable, Text, List
 import json
 
 
@@ -8,13 +8,13 @@ class Competency(object):
     Args:
         identifier: A unique identifier for this competency. Choose the identifier wisely as it will be used for equivalence with other competency objects
         name: A name for the competency (e.g. Microsoft Office)
-        category: An optional text category for the competency that is not a higher-level competency itself
+        categories: Optional text categories for the competency that is not a higher-level competency itself
     """
 
-    def __init__(self, identifier: Text, name: Text=None, category: Text=None, **kwargs):
+    def __init__(self, identifier: Text, name: Text=None, categories: List[Text]=None, **kwargs):
         self.identifier = identifier
         self.name = name or ''
-        self.category = category
+        self.categories = categories or []
         self.other_attributes = kwargs
         self.children = set()
         self.parents = set()
@@ -25,7 +25,7 @@ class Competency(object):
         obj = cls(
             identifier=jsonld_input['@id'],
             name=jsonld_input.get('name', ''),
-            category=jsonld_input.get('competencyCategory', None),
+            categories=jsonld_input.get('competencyCategory', None),
             **extra_kwargs
         )
         for jsonld_child_obj in jsonld_input.get('hasChild', []):
@@ -42,7 +42,7 @@ class Competency(object):
         return hash(self.identifier)
 
     def __repr__(self):
-        return f'Competency(identifier={self.identifier}, name={self.name}, category={self.category}, {self.other_attributes})'
+        return f'Competency(identifier={self.identifier}, name={self.name}, categories={self.categories}, {self.other_attributes})'
 
     @property
     def jsonld_id(self):
@@ -57,7 +57,7 @@ class Competency(object):
             '@type': 'Competency',
             '@id': self.identifier,
             'name': self.name,
-            'competencyCategory': self.category,
+            'competencyCategory': self.categories,
             'hasChild': [child.jsonld_id for child in self.children],
             'isChildOf': [parent.jsonld_id for parent in self.parents],
         }

--- a/skills_ml/ontologies/onet.py
+++ b/skills_ml/ontologies/onet.py
@@ -1,0 +1,64 @@
+from .base import Competency, Occupation, CompetencyOntology
+from skills_ml.datasets.onet_cache import OnetSiteCache
+import logging
+
+
+def build_onet(onet_cache=None):
+    if not onet_cache:
+        onet_cache = OnetSiteCache()
+
+    ontology = CompetencyOntology()
+    description_lookup = {}
+    logging.info('Processing Content Model Reference')
+    for row in onet_cache.reader('Content Model Reference'):
+        description_lookup[row['Element ID']] = row['Description']
+
+    logging.info('Processing occupation data')
+    for row in onet_cache.reader('Occupation Data'):
+        occupation = Occupation(
+            identifier=row['O*NET-SOC Code'],
+            name=row['Title'],
+            description=row['Description']
+        )
+        major_group_num = row['O*NET-SOC Code'][0:2]
+        major_group = Occupation(
+            identifier=major_group_num,
+            name=f'Major Group {major_group_num}'
+        )
+        occupation.add_parent(major_group)
+        ontology.add_occupation(occupation)
+        ontology.add_occupation(major_group)
+
+    logging.info('Processing Knowledge, Skills, Abilities')
+    for content_model_file in {'Knowledge', 'Abilities', 'Skills'}:
+        for row in onet_cache.reader(content_model_file):
+            competency = Competency(
+                identifier=row['Element ID'],
+                name=row['Element Name'],
+                category=content_model_file,
+                competencyText=description_lookup[row['Element ID']]
+            )
+            ontology.add_competency(competency)
+            occupation = Occupation(identifier=row['O*NET-SOC Code'])
+            ontology.add_edge(competency=competency, occupation=occupation)
+
+    logging.info('Processing tools and technology')
+    for row in onet_cache.reader('Tools and Technology'):
+        key = row['Commodity Code'] + '-' + row['T2 Example']
+        commodity_competency = Competency(
+            identifier=row['Commodity Code'],
+            name=row['Commodity Title'],
+            category=row['T2 Type'],
+        )
+        competency = Competency(
+            identifier=key,
+            name=row['T2 Example'],
+            category=row['T2 Type'],
+        )
+        competency.add_parent(commodity_competency)
+        ontology.add_competency(commodity_competency)
+        ontology.add_competency(competency)
+        occupation = Occupation(identifier=row['O*NET-SOC Code'])
+        ontology.add_edge(competency=competency, occupation=occupation)
+
+    return ontology

--- a/skills_ml/ontologies/onet.py
+++ b/skills_ml/ontologies/onet.py
@@ -3,6 +3,33 @@ from skills_ml.datasets.onet_cache import OnetSiteCache
 import logging
 
 
+majorgroupname = {
+    '11': 'Management Occupations',
+    '13': 'Business and Financial Operations Occupations',
+    '15': 'Computer and Mathematical Occupations',
+    '17': 'Architecture and Engineering Occupations',
+    '19': 'Life, Physical, and Social Science Occupations',
+    '21': 'Community and Social Service Occupations',
+    '23': 'Legal Occupations',
+    '25': 'Education, Training, and Library Occupations',
+    '27': 'Arts, Design, Entertainment, Sports, and Media Occupations',
+    '29': 'Healthcare Practitioners and Technical Occupations',
+    '31': 'Healthcare Support Occupations',
+    '33': 'Protective Service Occupations',
+    '35': 'Food Preparation and Serving Related Occupations',
+    '37': 'Building and Grounds Cleaning and Maintenance',
+    '39': 'Personal Care and Service Occupations',
+    '41': 'Sales and Related Occupations',
+    '43': 'Office and Administrative Support Occupations',
+    '45': 'Farming, Fishing, and Forestry Occupations',
+    '47': 'Construction and Extraction Occupations',
+    '49': 'Installation, Maintenance, and Repair Occupations',
+    '51': 'Production Occupations',
+    '53': 'Transportation and Material Moving Occupations',
+    '55': 'Military Specific Occupations'
+}
+
+
 def build_onet(onet_cache=None):
     if not onet_cache:
         onet_cache = OnetSiteCache()
@@ -18,12 +45,14 @@ def build_onet(onet_cache=None):
         occupation = Occupation(
             identifier=row['O*NET-SOC Code'],
             name=row['Title'],
-            description=row['Description']
+            description=row['Description'],
+            categories=['O*NET-SOC Occupation'],
         )
         major_group_num = row['O*NET-SOC Code'][0:2]
         major_group = Occupation(
             identifier=major_group_num,
-            name=f'Major Group {major_group_num}'
+            name=majorgroupname[major_group_num],
+            categories=['O*NET-SOC Major Group']
         )
         occupation.add_parent(major_group)
         ontology.add_occupation(occupation)
@@ -35,7 +64,7 @@ def build_onet(onet_cache=None):
             competency = Competency(
                 identifier=row['Element ID'],
                 name=row['Element Name'],
-                category=content_model_file,
+                categories=[content_model_file],
                 competencyText=description_lookup[row['Element ID']]
             )
             ontology.add_competency(competency)
@@ -48,12 +77,12 @@ def build_onet(onet_cache=None):
         commodity_competency = Competency(
             identifier=row['Commodity Code'],
             name=row['Commodity Title'],
-            category=row['T2 Type'],
+            categories=[row['T2 Type'], 'UNSPSC Commodity'],
         )
         competency = Competency(
             identifier=key,
             name=row['T2 Example'],
-            category=row['T2 Type'],
+            categories=[row['T2 Type'], 'O*NET T2'],
         )
         competency.add_parent(commodity_competency)
         ontology.add_competency(commodity_competency)

--- a/skills_ml/storage/__init__.py
+++ b/skills_ml/storage/__init__.py
@@ -1,12 +1,9 @@
-from skills_utils.s3 import split_s3_path
 import s3fs
-from sklearn.externals import joblib
 import os
 import json
-import io
 import logging
-import tempfile
 from collections.abc import MutableMapping
+
 
 class Store(object):
     def __init__(self, path):
@@ -79,6 +76,27 @@ class FSStore(Store):
 
     def list(self, subpath):
         return os.listdir(os.path.join(self.path, subpath))
+
+
+class InMemoryStore(Store):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.store = {}
+
+    def exists(self, fname):
+        return fname in self.store
+
+    def write(self, bytes_obj, fname):
+        self.store[fname] = bytes_obj
+
+    def load(self, fname):
+        return self.store[fname]
+
+    def delete(self, fname):
+        del self.store[fname]
+
+    def list(self, subpath):
+        return [key for key in self.store if key.startswith(subpath)]
 
 
 class PersistedJSONDict(MutableMapping):

--- a/tests/ontologies/test_base.py
+++ b/tests/ontologies/test_base.py
@@ -1,0 +1,317 @@
+from skills_ml.ontologies import Competency, Occupation, CompetencyOccupationEdge, CompetencyOntology
+from unittest import TestCase
+import json
+
+
+class CompetencyTest(TestCase):
+    def test_create(self):
+        # Should be able to create a competency with the necessary inputs
+        competency = Competency(identifier='123', name='communication', category='social skills')
+        assert competency.identifier == '123'
+        assert competency.name == 'communication'
+        assert competency.category == 'social skills'
+
+    def test_equivalence(self):
+        # Two competencies with the same id should be equivalent
+        competency = Competency(identifier='123', name='communication', category='social skills')
+        competency_two = Competency(identifier='123', name='communication', category='social skills')
+        assert competency == competency_two
+
+    def test_add_parent(self):
+        # Adding a parent should mutate the parents on self and the children on the parent
+        communication = Competency(identifier='123', name='communication', category='social skills')
+        listening = Competency(identifier='456', name='listening', category='social skills')
+        communication.add_parent(listening)
+        assert listening in communication.parents
+        assert communication in listening.children
+
+    def test_add_child(self):
+        # Adding a child should mutate the children on self and the parents on the child
+        communication = Competency(identifier='123', name='communication', category='social skills')
+        listening = Competency(identifier='456', name='listening', category='social skills')
+        listening.add_child(communication)
+        assert listening in communication.parents
+        assert communication in listening.children
+
+    def test_jsonld(self):
+        # The jsonld version of a competency should include all parent/child links, using the jsonld id
+        communication = Competency(identifier='123', name='communication', category='social skills')
+        listening = Competency(identifier='456', name='listening', category='social skills')
+        listening.add_child(communication)
+        assert listening.jsonld_full == {
+            '@type': 'Competency',
+            '@id': '456',
+            'name': 'listening',
+            'competencyCategory': 'social skills',
+            'hasChild': [{'@type': 'Competency', '@id': '123'}],
+            'isChildOf': [],
+        }
+
+    def test_from_jsonld(self):
+        jsonld_input = {
+            '@type': 'Competency',
+            '@id': '456',
+            'name': 'listening',
+            'competencyCategory': 'social skills',
+            'hasChild': [{'@type': 'Competency', '@id': '123'}],
+            'isChildOf': [],
+            'extra_kwarg': 'extra_value'
+        }
+
+        target_competency = Competency(identifier='456', name='listening', category='social skills', extra_kwarg='extra_value')
+        target_competency.add_child(Competency(identifier='123'))
+        competency = Competency.from_jsonld(jsonld_input)
+        assert competency == target_competency
+
+
+class OccupationTest(TestCase):
+    def test_create(self):
+        # Should be able to create an occupation with the necessary inputs
+        occupation = Occupation(identifier='456', name='Civil Engineer')
+        assert occupation.identifier == '456'
+        assert occupation.name == 'Civil Engineer'
+
+    def test_equivalence(self):
+        # Two occupations with the same id should be equivalent
+        occupation = Occupation(identifier='456', name='Civil Engineer')
+        occupation_two = Occupation(identifier='456', name='Civil Engineer')
+        assert occupation == occupation_two
+
+    def test_add_parent(self):
+        # Adding a parent should mutate the parents on self and the children on the parent
+        civil_engineer = Occupation(identifier='12-3', name='Civil Engineer')
+        engineers = Occupation(identifier='12', name='major group 12')
+        civil_engineer.add_parent(engineers)
+        assert engineers in civil_engineer.parents
+        assert civil_engineer in engineers.children
+
+    def test_add_child(self):
+        # Adding a child should mutate the children on self and the parents on the child
+        civil_engineer = Occupation(identifier='12-3', name='Civil Engineer')
+        engineers = Occupation(identifier='12', name='major group 12')
+        engineers.add_child(civil_engineer)
+        assert engineers in civil_engineer.parents
+        assert civil_engineer in engineers.children
+
+    def test_jsonld(self):
+        # The jsonld version of an occupation should include all parent/child links, using the jsonld id
+        civil_engineer = Occupation(identifier='12-3', name='Civil Engineer')
+        engineers = Occupation(identifier='12', name='major group 12')
+        engineers.add_child(civil_engineer)
+        assert civil_engineer.jsonld_full == {
+            '@type': 'Occupation',
+            '@id': '12-3',
+            'name': 'Civil Engineer',
+            'hasChild': [],
+            'isChildOf': [{'@type': 'Occupation', '@id': '12'}],
+        }
+
+    def test_from_jsonld(self):
+        jsonld_input = {
+            '@type': 'Occupation',
+            '@id': '12-3',
+            'name': 'Civil Engineer',
+            'hasChild': [],
+            'isChildOf': [{'@type': 'Occupation', '@id': '12'}],
+        }
+
+        target_occupation = Occupation(identifier='12-3', name='Civil Engineer')
+        target_occupation.add_parent(Occupation(identifier='12', name='major group 12'))
+        occupation = Occupation.from_jsonld(jsonld_input)
+        assert occupation == target_occupation
+
+
+class CompetencyOccupationEdgeTest(TestCase):
+    def test_create(self):
+        # Should be able to create an edge with a competency and occupation
+        competency = Competency(identifier='123', name='communication', category='social skills')
+        occupation = Occupation(identifier='456', name='Civil Engineer')
+        edge = CompetencyOccupationEdge(competency=competency, occupation=occupation)
+        assert edge.competency == competency
+        assert edge.occupation == occupation
+
+
+    def test_jsonld(self):
+        competency = Competency(identifier='111', name='communication', category='social skills')
+        occupation = Occupation(identifier='123', name='Civil Engineer')
+        edge = CompetencyOccupationEdge(competency=competency, occupation=occupation)
+        assert edge.jsonld_full == {
+            '@type': 'CompetencyOccupationEdge',
+            '@id': 'competency=111&occupation=123',
+            'competency': {
+                '@type': 'Competency',
+                '@id': '111'
+            },
+            'occupation': {
+                '@type': 'Occupation',
+                '@id': '123'
+            }
+        }
+
+    def test_fromjsonld(self):
+        jsonld_input = {
+            '@type': 'CompetencyOccupationEdge',
+            '@id': 'competency=111&occupation=123',
+            'competency': {
+                '@type': 'Competency',
+                '@id': '111'
+            },
+            'occupation': {
+                '@type': 'Occupation',
+                '@id': '123'
+            }
+        }
+
+        competency = Competency(identifier='111')
+        occupation = Occupation(identifier='123')
+        target_edge = CompetencyOccupationEdge(competency=competency, occupation=occupation)
+
+        edge = CompetencyOccupationEdge.from_jsonld(jsonld_input)
+        assert edge == target_edge
+
+    
+class OntologyTest(TestCase):
+    def test_add_competency(self):
+        # Should be able to add a competency to an ontology
+        competency = Competency(identifier='123', name='communication', category='social skills')
+        ontology = CompetencyOntology()
+        ontology.add_competency(competency)
+        assert len(ontology.competencies) == 1
+        assert competency in ontology.competencies
+
+    def test_add_occupation(self):
+        # Should be able to add an occupation to an ontology
+        occupation = Occupation(identifier='456', name='Civil Engineer')
+        ontology = CompetencyOntology()
+        ontology.add_occupation(occupation)
+        assert len(ontology.occupations) == 1
+        assert occupation in ontology.occupations
+
+    def test_add_edge(self):
+        # Should be able to add an edge between an occupation and a competency to an ontology
+        occupation = Occupation(identifier='456', name='Civil Engineer')
+        competency = Competency(identifier='123', name='communication', category='social skills')
+        ontology = CompetencyOntology()
+        ontology.add_edge(competency=competency, occupation=occupation)
+        assert competency in ontology.competencies
+        assert occupation in ontology.occupations
+        assert len([edge for edge in ontology.edges if edge.occupation == occupation and edge.competency == competency]) == 1
+
+    def test_filter_by(self):
+        # Should be able to take an ontology and filter it by the edges, returning a new sub-ontology
+        ontology = CompetencyOntology()
+        comm = Competency(identifier='123', name='communication', category='social skills')
+        python = Competency(identifier='999', name='python', category='Technologies')
+        math = Competency(identifier='111', name='mathematics', category='Knowledge')
+        science = Competency(identifier='222', name='science', category='Knowledge')
+
+        civil_engineer = Occupation(identifier='123', name='Civil Engineer')
+        ontology.add_competency(comm)
+        ontology.add_competency(python)
+        ontology.add_competency(math)
+        ontology.add_competency(science)
+        ontology.add_occupation(civil_engineer)
+        ontology.add_edge(occupation=civil_engineer, competency=math)
+        ontology.add_edge(occupation=civil_engineer, competency=science)
+
+        tech_ontology = ontology.filter_by(lambda edge: edge.competency.category == 'Technologies')
+        assert tech_ontology.competencies == {python}
+        assert len(tech_ontology.occupations) == 0
+
+        civil_engineer_ontology = ontology.filter_by(lambda edge: edge.occupation == civil_engineer)
+        assert civil_engineer_ontology.competencies == {math, science}
+        assert civil_engineer_ontology.occupations == {civil_engineer}
+
+    def ontology(self):
+        ontology = CompetencyOntology()
+        comm = Competency(identifier='123', name='communication', category='social skills')
+        python = Competency(identifier='999', name='python', category='Technologies')
+        math = Competency(identifier='111', name='mathematics', category='Knowledge')
+        science = Competency(identifier='222', name='science', category='Knowledge')
+
+        civil_engineer = Occupation(identifier='123', name='Civil Engineer')
+        ontology.add_competency(comm)
+        ontology.add_competency(python)
+        ontology.add_competency(math)
+        ontology.add_competency(science)
+        ontology.add_occupation(civil_engineer)
+        ontology.add_edge(occupation=civil_engineer, competency=math)
+        ontology.add_edge(occupation=civil_engineer, competency=science)
+        return ontology
+
+    def jsonld(self):
+        return json.dumps({
+            'occupations': [{
+                '@type': 'Occupation',
+                '@id': '123',
+                'name': 'Civil Engineer',
+                'hasChild': [],
+                'isChildOf': [],
+            }],
+            'competencies': [
+                {
+                    '@type': 'Competency',
+                    '@id': '111',
+                    'name': 'mathematics',
+                    'competencyCategory': 'Knowledge',
+                    'hasChild': [],
+                    'isChildOf': [],
+                },
+                {
+                    '@type': 'Competency',
+                    '@id': '123',
+                    'name': 'communication',
+                    'competencyCategory': 'social skills',
+                    'hasChild': [],
+                    'isChildOf': [],
+                },
+                {
+                    '@type': 'Competency',
+                    '@id': '222',
+                    'name': 'science',
+                    'competencyCategory': 'Knowledge',
+                    'hasChild': [],
+                    'isChildOf': [],
+                },
+                {
+                    '@type': 'Competency',
+                    '@id': '999',
+                    'name': 'python',
+                    'competencyCategory': 'Technologies',
+                    'hasChild': [],
+                    'isChildOf': [],
+                },
+            ],
+            'edges': [
+                {
+                    '@type': 'CompetencyOccupationEdge',
+                    '@id': 'competency=111&occupation=123',
+                    'competency': {
+                        '@type': 'Competency',
+                        '@id': '111'
+                    },
+                    'occupation': {
+                        '@type': 'Occupation',
+                        '@id': '123'
+                    }
+                },
+                {
+                    '@type': 'CompetencyOccupationEdge',
+                    '@id': 'competency=222&occupation=123',
+                    'competency': {
+                        '@type': 'Competency',
+                        '@id': '222'
+                    },
+                    'occupation': {
+                        '@type': 'Occupation',
+                        '@id': '123'
+                    }
+                }
+            ]
+        }, sort_keys=True)
+
+    def test_jsonld(self):
+        assert self.ontology().jsonld == self.jsonld()
+
+    def test_import_from_jsonld(self):
+        assert CompetencyOntology.from_jsonld(self.jsonld()) == self.ontology()

--- a/tests/ontologies/test_base.py
+++ b/tests/ontologies/test_base.py
@@ -6,43 +6,43 @@ import json
 class CompetencyTest(TestCase):
     def test_create(self):
         # Should be able to create a competency with the necessary inputs
-        competency = Competency(identifier='123', name='communication', category='social skills')
+        competency = Competency(identifier='123', name='communication', categories=['social skills'])
         assert competency.identifier == '123'
         assert competency.name == 'communication'
-        assert competency.category == 'social skills'
+        assert competency.categories[0] == 'social skills'
 
     def test_equivalence(self):
         # Two competencies with the same id should be equivalent
-        competency = Competency(identifier='123', name='communication', category='social skills')
-        competency_two = Competency(identifier='123', name='communication', category='social skills')
+        competency = Competency(identifier='123', name='communication', categories=['social skills'])
+        competency_two = Competency(identifier='123', name='communication', categories=['social skills'])
         assert competency == competency_two
 
     def test_add_parent(self):
         # Adding a parent should mutate the parents on self and the children on the parent
-        communication = Competency(identifier='123', name='communication', category='social skills')
-        listening = Competency(identifier='456', name='listening', category='social skills')
+        communication = Competency(identifier='123', name='communication', categories=['social skills'])
+        listening = Competency(identifier='456', name='listening', categories=['social skills'])
         communication.add_parent(listening)
         assert listening in communication.parents
         assert communication in listening.children
 
     def test_add_child(self):
         # Adding a child should mutate the children on self and the parents on the child
-        communication = Competency(identifier='123', name='communication', category='social skills')
-        listening = Competency(identifier='456', name='listening', category='social skills')
+        communication = Competency(identifier='123', name='communication', categories=['social skills'])
+        listening = Competency(identifier='456', name='listening', categories=['social skills'])
         listening.add_child(communication)
         assert listening in communication.parents
         assert communication in listening.children
 
     def test_jsonld(self):
         # The jsonld version of a competency should include all parent/child links, using the jsonld id
-        communication = Competency(identifier='123', name='communication', category='social skills')
-        listening = Competency(identifier='456', name='listening', category='social skills')
+        communication = Competency(identifier='123', name='communication', categories=['social skills'])
+        listening = Competency(identifier='456', name='listening', categories=['social skills'])
         listening.add_child(communication)
         assert listening.jsonld_full == {
             '@type': 'Competency',
             '@id': '456',
             'name': 'listening',
-            'competencyCategory': 'social skills',
+            'competencyCategory': ['social skills'],
             'hasChild': [{'@type': 'Competency', '@id': '123'}],
             'isChildOf': [],
         }
@@ -52,13 +52,13 @@ class CompetencyTest(TestCase):
             '@type': 'Competency',
             '@id': '456',
             'name': 'listening',
-            'competencyCategory': 'social skills',
+            'competencyCategory': ['social skills'],
             'hasChild': [{'@type': 'Competency', '@id': '123'}],
             'isChildOf': [],
             'extra_kwarg': 'extra_value'
         }
 
-        target_competency = Competency(identifier='456', name='listening', category='social skills', extra_kwarg='extra_value')
+        target_competency = Competency(identifier='456', name='listening', categories=['social skills'], extra_kwarg='extra_value')
         target_competency.add_child(Competency(identifier='123'))
         competency = Competency.from_jsonld(jsonld_input)
         assert competency == target_competency
@@ -124,7 +124,7 @@ class OccupationTest(TestCase):
 class CompetencyOccupationEdgeTest(TestCase):
     def test_create(self):
         # Should be able to create an edge with a competency and occupation
-        competency = Competency(identifier='123', name='communication', category='social skills')
+        competency = Competency(identifier='123', name='communication', categories=['social skills'])
         occupation = Occupation(identifier='456', name='Civil Engineer')
         edge = CompetencyOccupationEdge(competency=competency, occupation=occupation)
         assert edge.competency == competency
@@ -132,7 +132,7 @@ class CompetencyOccupationEdgeTest(TestCase):
 
 
     def test_jsonld(self):
-        competency = Competency(identifier='111', name='communication', category='social skills')
+        competency = Competency(identifier='111', name='communication', categories=['social skills'])
         occupation = Occupation(identifier='123', name='Civil Engineer')
         edge = CompetencyOccupationEdge(competency=competency, occupation=occupation)
         assert edge.jsonld_full == {
@@ -173,7 +173,7 @@ class CompetencyOccupationEdgeTest(TestCase):
 class OntologyTest(TestCase):
     def test_add_competency(self):
         # Should be able to add a competency to an ontology
-        competency = Competency(identifier='123', name='communication', category='social skills')
+        competency = Competency(identifier='123', name='communication', categories=['social skills'])
         ontology = CompetencyOntology()
         ontology.add_competency(competency)
         assert len(ontology.competencies) == 1
@@ -190,7 +190,7 @@ class OntologyTest(TestCase):
     def test_add_edge(self):
         # Should be able to add an edge between an occupation and a competency to an ontology
         occupation = Occupation(identifier='456', name='Civil Engineer')
-        competency = Competency(identifier='123', name='communication', category='social skills')
+        competency = Competency(identifier='123', name='communication', categories=['social skills'])
         ontology = CompetencyOntology()
         ontology.add_edge(competency=competency, occupation=occupation)
         assert competency in ontology.competencies
@@ -200,10 +200,10 @@ class OntologyTest(TestCase):
     def test_filter_by(self):
         # Should be able to take an ontology and filter it by the edges, returning a new sub-ontology
         ontology = CompetencyOntology()
-        comm = Competency(identifier='123', name='communication', category='social skills')
-        python = Competency(identifier='999', name='python', category='Technologies')
-        math = Competency(identifier='111', name='mathematics', category='Knowledge')
-        science = Competency(identifier='222', name='science', category='Knowledge')
+        comm = Competency(identifier='123', name='communication', categories=['social skills'])
+        python = Competency(identifier='999', name='python', categories=['Technologies'])
+        math = Competency(identifier='111', name='mathematics', categories=['Knowledge'])
+        science = Competency(identifier='222', name='science', categories=['Knowledge'])
 
         civil_engineer = Occupation(identifier='123', name='Civil Engineer')
         ontology.add_competency(comm)
@@ -214,7 +214,7 @@ class OntologyTest(TestCase):
         ontology.add_edge(occupation=civil_engineer, competency=math)
         ontology.add_edge(occupation=civil_engineer, competency=science)
 
-        tech_ontology = ontology.filter_by(lambda edge: edge.competency.category == 'Technologies')
+        tech_ontology = ontology.filter_by(lambda edge: 'Technologies' in edge.competency.categories)
         assert tech_ontology.competencies == {python}
         assert len(tech_ontology.occupations) == 0
 
@@ -224,10 +224,10 @@ class OntologyTest(TestCase):
 
     def ontology(self):
         ontology = CompetencyOntology()
-        comm = Competency(identifier='123', name='communication', category='social skills')
-        python = Competency(identifier='999', name='python', category='Technologies')
-        math = Competency(identifier='111', name='mathematics', category='Knowledge')
-        science = Competency(identifier='222', name='science', category='Knowledge')
+        comm = Competency(identifier='123', name='communication', categories=['social skills'])
+        python = Competency(identifier='999', name='python', categories=['Technologies'])
+        math = Competency(identifier='111', name='mathematics', categories=['Knowledge'])
+        science = Competency(identifier='222', name='science', categories=['Knowledge'])
 
         civil_engineer = Occupation(identifier='123', name='Civil Engineer')
         ontology.add_competency(comm)
@@ -253,7 +253,7 @@ class OntologyTest(TestCase):
                     '@type': 'Competency',
                     '@id': '111',
                     'name': 'mathematics',
-                    'competencyCategory': 'Knowledge',
+                    'competencyCategory': ['Knowledge'],
                     'hasChild': [],
                     'isChildOf': [],
                 },
@@ -261,7 +261,7 @@ class OntologyTest(TestCase):
                     '@type': 'Competency',
                     '@id': '123',
                     'name': 'communication',
-                    'competencyCategory': 'social skills',
+                    'competencyCategory': ['social skills'],
                     'hasChild': [],
                     'isChildOf': [],
                 },
@@ -269,7 +269,7 @@ class OntologyTest(TestCase):
                     '@type': 'Competency',
                     '@id': '222',
                     'name': 'science',
-                    'competencyCategory': 'Knowledge',
+                    'competencyCategory': ['Knowledge'],
                     'hasChild': [],
                     'isChildOf': [],
                 },
@@ -277,7 +277,7 @@ class OntologyTest(TestCase):
                     '@type': 'Competency',
                     '@id': '999',
                     'name': 'python',
-                    'competencyCategory': 'Technologies',
+                    'competencyCategory': ['Technologies'],
                     'hasChild': [],
                     'isChildOf': [],
                 },


### PR DESCRIPTION
This commit introduces the CompetencyOntology class, which covers competencies and the occupations that they are associated with. ONET is provided as  a sample ontology.

- Add skills_ml.ontologies with base class and ONET
- Refactor ONET dataset source modules so that it is easier to use without dependencies
- Add documentation page about ontology class
- Add InMemoryStore to make ONET more usable upfront