### PR TITLE
Apply Ontology to Skill Extraction [Resolves #198]

### DIFF
--- a/docs/pydocmd.yml
+++ b/docs/pydocmd.yml
@@ -7,13 +7,14 @@ generate:
     skills_ml.algorithms.job_normalizers.elasticsearch+, skills_ml.algorithms.job_normalizers.esa_jobtitle_normalizer+,
     skills_ml.algorithms.jobtitle_cleaner+, skills_ml.algorithms.jobtitle_cleaner.clean+,
     skills_ml.algorithms.occupation_classifiers+, skills_ml.algorithms.occupation_classifiers.classifiers+,
-    skills_ml.algorithms.sampling+, skills_ml.algorithms.sampling.methods+, skills_ml.algorithms.skill_extractors+,
+    skills_ml.algorithms.occupation_classifiers.train+, skills_ml.algorithms.sampling+,
+    skills_ml.algorithms.sampling.methods+, skills_ml.algorithms.skill_extractors+,
     skills_ml.algorithms.skill_extractors.base+, skills_ml.algorithms.skill_extractors.exact_match+,
     skills_ml.algorithms.skill_extractors.fuzzy_match+, skills_ml.algorithms.skill_extractors.noun_phrase_ending+,
-    skills_ml.algorithms.skill_extractors.soc_exact+, skills_ml.algorithms.skill_feature_creator+,
-    skills_ml.algorithms.skill_feature_creator.contextual_features+, skills_ml.algorithms.skill_feature_creator.posTags+,
-    skills_ml.algorithms.skill_feature_creator.structure_features+, skills_ml.algorithms.string_cleaners+,
-    skills_ml.algorithms.string_cleaners.nlp+]
+    skills_ml.algorithms.skill_extractors.soc_exact+, skills_ml.algorithms.skill_extractors.symspell+,
+    skills_ml.algorithms.skill_feature_creator+, skills_ml.algorithms.skill_feature_creator.contextual_features+,
+    skills_ml.algorithms.skill_feature_creator.posTags+, skills_ml.algorithms.skill_feature_creator.structure_features+,
+    skills_ml.algorithms.string_cleaners+, skills_ml.algorithms.string_cleaners.nlp+]
 - skills_ml.datasets.md: [skills_ml.datasets.cbsa_shapefile+, skills_ml.datasets.cousub_ua+,
     skills_ml.datasets.job_titles+, skills_ml.datasets.job_titles.elasticsearch+,
     skills_ml.datasets.job_titles.onet+, skills_ml.datasets.nber_county_cbsa+, skills_ml.datasets.negative_positive_dict+,
@@ -29,9 +30,9 @@ generate:
     skills_ml.job_postings.aggregate.field_values+, skills_ml.job_postings.aggregate.pandas+,
     skills_ml.job_postings.common_schema+, skills_ml.job_postings.computed_properties+,
     skills_ml.job_postings.computed_properties.aggregators+, skills_ml.job_postings.computed_properties.computers+,
-    skills_ml.job_postings.corpora+, skills_ml.job_postings.filtering+,
-    skills_ml.job_postings.geography_queriers+, skills_ml.job_postings.geography_queriers.cbsa+,
-    skills_ml.job_postings.geography_queriers.cbsa_from_geocode+, skills_ml.job_postings.raw+,
+    skills_ml.job_postings.corpora+, skills_ml.job_postings.filtering+, skills_ml.job_postings.geography_queriers+,
+    skills_ml.job_postings.geography_queriers.base+, skills_ml.job_postings.geography_queriers.cbsa+,
+    skills_ml.job_postings.geography_queriers.state+, skills_ml.job_postings.raw+,
     skills_ml.job_postings.raw.usajobs+, skills_ml.job_postings.raw.virginia+, skills_ml.job_postings.sample+]
 gens_dir: _build/pydocmd
 loader: pydocmd.loader.PythonLoader

--- a/skills_ml/algorithms/skill_extractors/exact_match.py
+++ b/skills_ml/algorithms/skill_extractors/exact_match.py
@@ -1,9 +1,6 @@
 """Use exact matching with a source list to find skills"""
 
-import unicodecsv as csv
 import logging
-from smart_open import smart_open
-import re
 
 import nltk
 try:
@@ -11,7 +8,12 @@ try:
 except LookupError:
     nltk.download('punkt')
 
-from .base import CandidateSkill, ListBasedSkillExtractor, CandidateSkillYielder
+from .base import (
+    CandidateSkill,
+    ListBasedSkillExtractor,
+    CandidateSkillYielder,
+    trie_regex_from_words
+)
 
 from typing import Dict
 
@@ -19,28 +21,36 @@ from typing import Dict
 class ExactMatchSkillExtractor(ListBasedSkillExtractor):
     """Extract skills from unstructured text
 
+    Builds a lookup based on the 'name' attribute of all competencies in the given framework
+
     Originally written by Kwame Porter Robinson
     """
     method_name = 'exact_match'
     method_description = 'Exact matching'
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        list_entries = set(
+            competency.name
+            for competency in self.competency_framework.values()
+        )
+        logging.info(
+            'Found %s entries for lookup',
+            len(list_entries)
+        )
+        self.lookup_regex = trie_regex_from_words(list_entries)
+
     def _skills_lookup(self) -> set:
         """Create skills lookup
 
-        Reads the object's filename containing skills into a lookup
+        Read names from Ontology into a set
 
         Returns: (set) skill names
         """
-        logging.info('Creating skills lookup from %s', self.skill_lookup_path)
-        with smart_open(self.skill_lookup_path) as infile:
-            reader = csv.reader(infile, delimiter='\t')
-            header = next(reader)
-            index = header.index(self.nlp.transforms[0])
-            generator = (row[index] for row in reader)
-            return set(generator)
 
-    def candidate_skills(self, source_object:Dict) -> CandidateSkillYielder:
-        """Yield objects which may represent skills/competencies from the given source object.
+    def candidate_skills(self, source_object: Dict) -> CandidateSkillYielder:
+        """Yield objects which may represent skills from the given source object.
 
         Looks for exact matches between the reference skill lookup and the object's text.
 
@@ -51,4 +61,12 @@ class ExactMatchSkillExtractor(ListBasedSkillExtractor):
         document = self.transform_func(source_object)
         sentences = self.nlp.sentence_tokenize(document)
         for sent in sentences:
-            yield from self.candidate_skills_in_context(sent)
+            matches = self.lookup_regex.findall(sent)
+            for match in matches: 
+                logging.info('Yielding exact match %s in string %s', match, sent)
+                yield CandidateSkill(
+                    skill_name=match.lower(),
+                    matched_skill=match,
+                    confidence=100,
+                    context=sent
+                )

--- a/skills_ml/algorithms/skill_extractors/soc_exact.py
+++ b/skills_ml/algorithms/skill_extractors/soc_exact.py
@@ -5,6 +5,8 @@ import unicodecsv as csv
 
 from smart_open import smart_open
 
+from skills_ml.ontologies.base import CompetencyOntology
+
 from .base import CandidateSkill, trie_regex_from_words
 from .exact_match import ExactMatchSkillExtractor
 
@@ -16,41 +18,22 @@ class SocScopedExactMatchSkillExtractor(ExactMatchSkillExtractor):
     method_name = 'occscoped_exact_match'
     method_description = 'Exact matching using only the skills known by ONET to be associated with the given SOC code'
 
-    def _skills_lookup(self):
-        """Create skills lookup
+    def __init__(self, competency_ontology, *args, **kwargs):
+        if not isinstance(competency_ontology, CompetencyOntology):
+            raise ValueError('Must pass in a CompetencyOntology object')
+        super().__init__(competency_ontology.competency_framework, *args, **kwargs)
 
-        Reads the object's filename containing skills into a lookup
-
-        Returns: (set) skill names
-        """
-        logging.info('Creating skills lookup from %s', self.skill_lookup_path)
-        lookup = defaultdict(set)
-        with smart_open(self.skill_lookup_path) as infile:
-            reader = csv.reader(infile, delimiter='\t')
-            header = next(reader)
-            ksa_index = header.index('ONET KSA')
-            soc_index = header.index('O*NET-SOC Code')
-            for row in reader:
-                lookup[row[soc_index]].add(row[ksa_index])
-            return lookup
+        self.skill_extractor_by_soc = {}
+        for occupation in competency_ontology.occupations:
+            subontology = competency_ontology.filter_by(
+                lambda edge: edge.occupation == occupation,
+                competency_name='competencies_' + occupation.identifier,
+                competency_description='Competencies needed by ' + occupation.name
+            )
+            self.skill_extractor_by_soc[occupation.identifier] = ExactMatchSkillExtractor(subontology.competency_framework)
 
     def candidate_skills(self, source_object):
-        document = self.transform_func(source_object)
-        sentences = self.nlp.sentence_tokenize(document)
-
         soc_code = source_object.get('onet_soc_code', None)
-        if not soc_code or soc_code not in self.lookup:
+        if not soc_code or soc_code not in self.skill_extractor_by_soc:
             return
-
-        soc_trie_regex = trie_regex_from_words(self.lookup[soc_code])
-
-        for sent in sentences:
-            matches = soc_trie_regex.findall(sent)
-            for match in matches: 
-                logging.info('Yielding exact match %s in string %s', match, sent)
-                yield CandidateSkill(
-                    skill_name=match.lower(),
-                    matched_skill=match,
-                    confidence=100,
-                    context=sent
-                )
+        yield from self.skill_extractor_by_soc[soc_code].candidate_skills(source_object)

--- a/skills_ml/ontologies/__init__.py
+++ b/skills_ml/ontologies/__init__.py
@@ -1,7 +1,8 @@
-from .base import Competency, Occupation, CompetencyOccupationEdge, CompetencyOntology
+from .base import Competency, Occupation, CompetencyOccupationEdge, CompetencyOntology, CompetencyFramework
 
 __all__ = (
     'Competency',
+    'CompetencyFramework',
     'Occupation',
     'CompetencyOccupationEdge',
     'CompetencyOntology'

--- a/skills_ml/ontologies/onet.py
+++ b/skills_ml/ontologies/onet.py
@@ -36,6 +36,8 @@ class Onet(CompetencyOntology):
         super().__init__()
         self.is_built = False
         self.onet_cache = onet_cache or OnetSiteCache()
+        self.competency_framework.name = 'onet_ksat'
+        self.competency_framework.description = 'ONET Knowledge, Skills, Abilities, Tools, and Technology'
         self._build()
 
     def _build(self):

--- a/tests/algorithms/skill_extractors/__init__.py
+++ b/tests/algorithms/skill_extractors/__init__.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 from skills_ml.job_postings import JobPosting
+from skills_ml.ontologies.base import CompetencyFramework, Competency, Occupation, CompetencyOntology, CompetencyOccupationEdge
 
 
 @pytest.fixture
@@ -13,12 +14,37 @@ def sample_job_posting():
     }
 
 
-@pytest.fixture
-def sample_skills():
-    return [
-        ['', 'O*NET-SOC Code', 'Element ID', 'ONET KSA', 'Description', 'skill_uuid', 'nlp_a'],
-        ['1', '11-1011.00', '2.a.1.a', 'organization', '...', '...', 'organization'],
-        ['2', '11-1011.00', '2.a.1.b', 'communication skills', '...', '...', 'communication skills'],
-        ['3', '11-1011.00', '2.a.1.b', 'cooking', '...', '...', 'cooking'],
-        ['4', '11-1012.00', '2.a.1.a', 'organization', '...', '...', 'organization'],
-    ]
+def sample_framework():
+    return CompetencyFramework(
+        name='Sample Framework',
+        description='A few basic competencies',
+        competencies=[
+            Competency(identifier='a', name='Organization'),
+            Competency(identifier='b', name='Communication Skills'),
+            Competency(identifier='c', name='Cooking')
+        ]
+    )
+
+def sample_ontology():
+    return CompetencyOntology(
+        competency_name='Sample Framework',
+        competency_description='A few basic competencies',
+        edges=[
+            CompetencyOccupationEdge(
+                competency=Competency(identifier='a', name='Organization'),
+                occupation=Occupation(identifier='11-1011.00')
+            ),
+            CompetencyOccupationEdge(
+                competency=Competency(identifier='a', name='Organization'),
+                occupation=Occupation(identifier='11-1012.00')
+            ),
+            CompetencyOccupationEdge(
+                competency=Competency(identifier='b', name='Communication Skills'),
+                occupation=Occupation(identifier='11-1011.00')
+            ),
+            CompetencyOccupationEdge(
+                competency=Competency(identifier='c', name='Cooking'),
+                occupation=Occupation(identifier='11-1011.00')
+            ),
+        ]
+    )

--- a/tests/algorithms/skill_extractors/test_exact_match.py
+++ b/tests/algorithms/skill_extractors/test_exact_match.py
@@ -1,46 +1,51 @@
 from collections import Counter
 
 from tests import utils
-from . import sample_skills, sample_job_posting
+from . import sample_framework, sample_job_posting
 
 from skills_ml.algorithms.skill_extractors import ExactMatchSkillExtractor
+from skills_ml.ontologies.base import CompetencyFramework, Competency
 
 
 def test_exactmatch_skill_extractor():
-    content = [
-        ['', 'O*NET-SOC Code', 'Element ID', 'ONET KSA', 'Description', 'skill_uuid', 'nlp_a'],
-        ['1', '11-1011.00', '2.a.1.a', 'reading comprehension', '...', '2c77c703bd66e104c78b1392c3203362', 'reading comprehension'],
-        ['2', '11-1011.00', '2.a.1.b', 'active listening', '...', 'a636cb69257dcec699bce4f023a05126', 'active listening']
-    ]
-    with utils.makeNamedTemporaryCSV(content, '\t') as skills_filename:
-        extractor = ExactMatchSkillExtractor(skill_lookup_path=skills_filename)
-        result = [extractor.document_skill_counts({'description': doc}) for doc in [
-            'this is a job that needs active listening',
-            'this is a reading comprehension job',
-            'this is an active and reading listening job',
-            'this is a reading comprehension and active listening job',
-        ]]
-
-        assert result == [
-            Counter({'active listening': 1}),
-            Counter({'reading comprehension': 1}),
-            Counter(),
-            Counter({'active listening': 1, 'reading comprehension': 1})
+    competency_framework = CompetencyFramework(
+        name='test_competencies',
+        description='Test competencies',
+        competencies=[
+            Competency(identifier='2.a.1.a', name='Reading Comprehension'),
+            Competency(identifier='2.a.1.b', name='Active Listening'),
         ]
+    )
+    extractor = ExactMatchSkillExtractor(competency_framework)
+    assert competency_framework.name in extractor.name
+    assert competency_framework.description in extractor.description
+
+    result = [extractor.document_skill_counts({'description': doc}) for doc in [
+        'this is a job that needs active listening',
+        'this is a reading comprehension job',
+        'this is an active and reading listening job',
+        'this is a reading comprehension and active listening job',
+    ]]
+
+    assert result == [
+        Counter({'active listening': 1}),
+        Counter({'reading comprehension': 1}),
+        Counter(),
+        Counter({'active listening': 1, 'reading comprehension': 1})
+    ]
 
 
 def test_exactmatch_skill_extractor_candidate_skills():
-    with utils.makeNamedTemporaryCSV(sample_skills(), '\t') as skills_filename:
-        extractor = ExactMatchSkillExtractor(skill_lookup_path=skills_filename)
-        candidate_skills = sorted(
-            extractor.candidate_skills(sample_job_posting()),
-            key=lambda cs: cs.skill_name
-        )
+    extractor = ExactMatchSkillExtractor(sample_framework())
+    candidate_skills = sorted(
+        extractor.candidate_skills(sample_job_posting()),
+        key=lambda cs: cs.skill_name
+    )
 
-        assert candidate_skills[0].skill_name == 'cooking'
-        assert candidate_skills[0].context == 'One-two years cooking experience in a professional kitchen'
-        assert candidate_skills[0].confidence == 100
+    assert candidate_skills[0].skill_name == 'cooking'
+    assert candidate_skills[0].context == 'One-two years cooking experience in a professional kitchen'
+    assert candidate_skills[0].confidence == 100
 
-        assert candidate_skills[1].skill_name == 'organization'
-        assert candidate_skills[1].context == 'Organization, Cleanliness, Trainability, team player, good communication skillz, Motivation, a Sense of Responsibility and Pride in your Performance'
-        assert candidate_skills[1].confidence == 100
+    assert candidate_skills[1].skill_name == 'organization'
+    assert candidate_skills[1].context == 'Organization, Cleanliness, Trainability, team player, good communication skillz, Motivation, a Sense of Responsibility and Pride in your Performance'
+    assert candidate_skills[1].confidence == 100

--- a/tests/algorithms/skill_extractors/test_fuzzy_match.py
+++ b/tests/algorithms/skill_extractors/test_fuzzy_match.py
@@ -1,28 +1,24 @@
-from tests import utils
-from tests.algorithms.skill_extractors import sample_skills, sample_job_posting
+from tests.algorithms.skill_extractors import sample_framework, sample_job_posting
 
 from skills_ml.algorithms.skill_extractors import FuzzyMatchSkillExtractor
 
 
 def test_fuzzymatch_skill_extractor_candidate_skills():
-    with utils.makeNamedTemporaryCSV(sample_skills(), '\t') as skills_filename:
-        extractor = FuzzyMatchSkillExtractor(skill_lookup_path=skills_filename)
-        candidate_skills = sorted(
-            extractor.candidate_skills(sample_job_posting()),
-            key=lambda cs: cs.skill_name
-        )
+    extractor = FuzzyMatchSkillExtractor(sample_framework())
+    candidate_skills = sorted(
+        extractor.candidate_skills(sample_job_posting()),
+        key=lambda cs: cs.skill_name
+    )
 
-        for cs in candidate_skills:
-            print(cs.skill_name)
-        assert candidate_skills[0].skill_name == 'communication skillz'
-        assert candidate_skills[0].matched_skill == 'communication skills'
-        assert candidate_skills[0].context == 'Organization, Cleanliness, Trainability, team player, good communication skillz, Motivation, a Sense of Responsibility and Pride in your Performance'
-        assert candidate_skills[0].confidence == 95
+    assert candidate_skills[0].skill_name == 'communication skillz'
+    assert candidate_skills[0].matched_skill == 'communication skills'
+    assert candidate_skills[0].context == 'Organization, Cleanliness, Trainability, team player, good communication skillz, Motivation, a Sense of Responsibility and Pride in your Performance'
+    assert candidate_skills[0].confidence == 95
 
-        assert candidate_skills[1].skill_name == 'cooking'
-        assert candidate_skills[1].context == 'One-two years cooking experience in a professional kitchen'
-        assert candidate_skills[1].confidence == 100
+    assert candidate_skills[1].skill_name == 'cooking'
+    assert candidate_skills[1].context == 'One-two years cooking experience in a professional kitchen'
+    assert candidate_skills[1].confidence == 100
 
-        assert candidate_skills[2].skill_name == 'organization'
-        assert candidate_skills[2].context == 'Organization, Cleanliness, Trainability, team player, good communication skillz, Motivation, a Sense of Responsibility and Pride in your Performance'
-        assert candidate_skills[2].confidence == 100
+    assert candidate_skills[2].skill_name == 'organization'
+    assert candidate_skills[2].context == 'Organization, Cleanliness, Trainability, team player, good communication skillz, Motivation, a Sense of Responsibility and Pride in your Performance'
+    assert candidate_skills[2].confidence == 100

--- a/tests/algorithms/skill_extractors/test_soc_exact.py
+++ b/tests/algorithms/skill_extractors/test_soc_exact.py
@@ -1,94 +1,101 @@
 from collections import Counter
 
-from tests import utils
-from . import sample_skills, sample_job_posting
+from . import sample_ontology, sample_job_posting
 
 from skills_ml.algorithms.skill_extractors import SocScopedExactMatchSkillExtractor
+from skills_ml.ontologies.base import CompetencyOntology, Competency, Occupation, CompetencyOccupationEdge
 
 
 def test_occupation_scoped_freetext_skill_extractor():
-    content = [
-        ['', 'O*NET-SOC Code', 'Element ID', 'ONET KSA', 'Description', 'skill_uuid', 'nlp_a'],
-        ['1', '11-1011.00', '2.a.1.a', 'reading comprehension', '...', '2c77c703bd66e104c78b1392c3203362', 'reading comprehension'],
-        ['2', '11-1011.00', '2.a.1.b', 'active listening', '...', 'a636cb69257dcec699bce4f023a05126', 'active listening']
-    ]
-    with utils.makeNamedTemporaryCSV(content, '\t') as skills_filename:
-        extractor = SocScopedExactMatchSkillExtractor(skill_lookup_path=skills_filename)
-        documents = [
-            {
-                'onet_soc_code': '11-1011.00',
-                'description': 'this is a job that needs active listening', 
-                'expected_value': Counter({'active listening': 1})
-            },
-            {
-                'onet_soc_code': '11-1011.00',
-                'description': 'this is a reading comprehension job',
-                'expected_value': Counter({'reading comprehension': 1})
-            },
-            {
-                'onet_soc_code': '11-1011.00',
-                'description': 'this is an active and reading listening job', 
-                'expected_value': Counter(),
-            },
-            {
-                'onet_soc_code': '11-1011.00',
-                'description': 'this is a reading comprehension and active listening job', 
-                'expected_value': Counter({'active listening': 1, 'reading comprehension': 1})
-            },
-            {
-                'onet_soc_code': '11-1021.00',
-                'description': 'this is a job that needs active listening', 
-                'expected_value': Counter()
-            },
-            {
-                'onet_soc_code': '11-1021.00',
-                'description': 'this is a reading comprehension job',
-                'expected_value': Counter()
-            },
-            {
-                'onet_soc_code': '11-1021.00',
-                'description': 'this is an active and reading listening job', 
-                'expected_value': Counter(),
-            },
-            {
-                'onet_soc_code': '11-1021.00',
-                'description': 'this is a reading comprehension and active listening job', 
-                'expected_value': Counter()
-            },
-            {
-                'onet_soc_code': None,
-                'description': 'this is a job that needs active listening', 
-                'expected_value': Counter()
-            },
-            {
-                'onet_soc_code': None,
-                'description': 'this is a reading comprehension job',
-                'expected_value': Counter()
-            },
-            {
-                'onet_soc_code': None,
-                'description': 'this is an active and reading listening job', 
-                'expected_value': Counter(),
-            },
-            {
-                'onet_soc_code': None,
-                'description': 'this is a reading comprehension and active listening job', 
-                'expected_value': Counter()
-            },
+    ontology = CompetencyOntology(
+        competency_name='Sample Framework',
+        competency_description='A few basic competencies',
+        edges=[
+            CompetencyOccupationEdge(
+                competency=Competency(identifier='2.a.1.a', name='Reading Comprehension'),
+                occupation=Occupation(identifier='11-1011.00')
+            ),
+            CompetencyOccupationEdge(
+                competency=Competency(identifier='2.a.1.b', name='Active Listening'),
+                occupation=Occupation(identifier='11-1011.00')
+            ),
         ]
-        for document in documents:
-            assert extractor.document_skill_counts(document) == document['expected_value']
+    )
+    extractor = SocScopedExactMatchSkillExtractor(ontology)
+    documents = [
+        {
+            'onet_soc_code': '11-1011.00',
+            'description': 'this is a job that needs active listening', 
+            'expected_value': Counter({'active listening': 1})
+        },
+        {
+            'onet_soc_code': '11-1011.00',
+            'description': 'this is a reading comprehension job',
+            'expected_value': Counter({'reading comprehension': 1})
+        },
+        {
+            'onet_soc_code': '11-1011.00',
+            'description': 'this is an active and reading listening job', 
+            'expected_value': Counter(),
+        },
+        {
+            'onet_soc_code': '11-1011.00',
+            'description': 'this is a reading comprehension and active listening job', 
+            'expected_value': Counter({'active listening': 1, 'reading comprehension': 1})
+        },
+        {
+            'onet_soc_code': '11-1021.00',
+            'description': 'this is a job that needs active listening', 
+            'expected_value': Counter()
+        },
+        {
+            'onet_soc_code': '11-1021.00',
+            'description': 'this is a reading comprehension job',
+            'expected_value': Counter()
+        },
+        {
+            'onet_soc_code': '11-1021.00',
+            'description': 'this is an active and reading listening job', 
+            'expected_value': Counter(),
+        },
+        {
+            'onet_soc_code': '11-1021.00',
+            'description': 'this is a reading comprehension and active listening job', 
+            'expected_value': Counter()
+        },
+        {
+            'onet_soc_code': None,
+            'description': 'this is a job that needs active listening', 
+            'expected_value': Counter()
+        },
+        {
+            'onet_soc_code': None,
+            'description': 'this is a reading comprehension job',
+            'expected_value': Counter()
+        },
+        {
+            'onet_soc_code': None,
+            'description': 'this is an active and reading listening job', 
+            'expected_value': Counter(),
+        },
+        {
+            'onet_soc_code': None,
+            'description': 'this is a reading comprehension and active listening job', 
+            'expected_value': Counter()
+        },
+    ]
+    for document in documents:
+        assert extractor.document_skill_counts(document) == document['expected_value']
 
 
 
 def test_occupational_scoped_skill_extractor_candidate_skills():
-    with utils.makeNamedTemporaryCSV(sample_skills(), '\t') as skills_filename:
-        extractor = SocScopedExactMatchSkillExtractor(skill_lookup_path=skills_filename)
-        candidate_skills = sorted(
-            extractor.candidate_skills(sample_job_posting()),
-            key=lambda cs: cs.skill_name
-        )
+    extractor = SocScopedExactMatchSkillExtractor(sample_ontology())
+    candidate_skills = sorted(
+        extractor.candidate_skills(sample_job_posting()),
+        key=lambda cs: cs.skill_name
+    )
 
-        assert candidate_skills[0].skill_name == 'organization'
-        assert candidate_skills[0].context == 'Organization, Cleanliness, Trainability, team player, good communication skillz, Motivation, a Sense of Responsibility and Pride in your Performance'
-        assert candidate_skills[0].confidence == 100
+    assert candidate_skills[0].skill_name == 'organization'
+    assert candidate_skills[0].context == 'Organization, Cleanliness, Trainability, team player, good communication skillz, Motivation, a Sense of Responsibility and Pride in your Performance'
+    assert candidate_skills[0].confidence == 100

--- a/tests/job_postings/test_computed_properties.py
+++ b/tests/job_postings/test_computed_properties.py
@@ -195,12 +195,8 @@ class SkillExtractTest(ComputedPropertyTestCase):
         s3_conn = boto.connect_s3()
         client = boto3.resource('s3')
         bucket = client.create_bucket(Bucket='test-bucket')
-        skills_path = 's3://test-bucket/skills_master_table.tsv'
-        utils.create_skills_file(skills_path)
         storage = S3Store('s3://test-bucket/computed_properties')
-        skill_extractor = ExactMatchSkillExtractor(
-            skill_lookup_path=skills_path,
-        )
+        skill_extractor = ExactMatchSkillExtractor(utils.sample_framework())
         self.computed_property = SkillCounts(
             skill_extractor=skill_extractor,
             storage=storage,
@@ -214,5 +210,5 @@ class SkillExtractTest(ComputedPropertyTestCase):
     def test_compute_func(self):
         cache = self.computed_property.cache_for_key(self.datestring)
         job_posting_id = self.job_postings[0]['id']
-        assert cache[job_posting_id] == {'skill_counts_onet_ksat_exact_match': ['reading comprehension']}
+        assert cache[job_posting_id] == {'skill_counts_sample_framework_exact_match': ['reading comprehension']}
 

--- a/tests/ontologies/test_base.py
+++ b/tests/ontologies/test_base.py
@@ -1,4 +1,4 @@
-from skills_ml.ontologies import Competency, Occupation, CompetencyOccupationEdge, CompetencyOntology
+from skills_ml.ontologies import Competency, Occupation, CompetencyOccupationEdge, CompetencyOntology, CompetencyFramework
 from unittest import TestCase
 import json
 
@@ -62,6 +62,27 @@ class CompetencyTest(TestCase):
         target_competency.add_child(Competency(identifier='123'))
         competency = Competency.from_jsonld(jsonld_input)
         assert competency == target_competency
+
+
+class CompetencyFrameworkTest(TestCase):
+    def test_create(self):
+        competency = Competency(identifier='1', name='Doing Things', competencyText='The ability to do things')
+        framework = CompetencyFramework(
+            name='fundamentals_of_nothing',
+            description='Fundamentals of Nothing',
+            competencies=[competency]
+        )
+        assert len(framework) == 1
+        assert framework['1'].name == 'Doing Things'
+
+    def test_add(self):
+        framework = CompetencyFramework(
+            name='fundamentals_of_nothing',
+            description='Fundamentals of Nothing',
+        )
+        competency = Competency(identifier='1', name='Doing Things', competencyText='The ability to do things')
+        framework.add(competency)
+        assert len(framework) == 1
 
 
 class OccupationTest(TestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,9 @@
 import unicodecsv as csv
 import json
 import tempfile
-import s3fs
 
 from contextlib import contextmanager
+from skills_ml.ontologies.base import CompetencyFramework, Competency
 
 
 @contextmanager
@@ -30,14 +30,12 @@ def job_posting_factory(**kwargs):
         return sample_job_posting
 
 
-def create_skills_file(skills_file_path):
-    content = [
-        ['', 'O*NET-SOC Code', 'Element ID', 'ONET KSA', 'Description', 'skill_uuid', 'nlp_a'],
-        ['1', '11-1011.00', '2.a.1.a', 'reading comprehension', '...', '2c77c703bd66e104c78b1392c3203362', 'reading comprehension'],
-        ['2', '11-1011.00', '2.a.1.b', 'active listening', '...', 'a636cb69257dcec699bce4f023a05126', 'active listening']
-    ]
-    s3 = s3fs.S3FileSystem()
-    with s3.open(skills_file_path, 'wb') as write_stream:
-        writer = csv.writer(write_stream, delimiter='\t')
-        for row in content:
-            writer.writerow(row)
+def sample_framework():
+    return CompetencyFramework(
+        name='sample_framework',
+        description='A few basic competencies',
+        competencies=[
+            Competency(identifier='a', name='Reading Comprehension'),
+            Competency(identifier='b', name='Active Listening'),
+        ]
+    )


### PR DESCRIPTION
- Add CompetencyFramework to CompetencyOntology to encapsulate just the competency part along with metadata
- Modify all list-based skill extractors to take either a CompetencyFramework or CompetencyOntology
- Update documentation and examples to include new functionality