### PR TITLE
More wage fixes

### DIFF
--- a/skills_ml/job_postings/computed_properties/computers.py
+++ b/skills_ml/job_postings/computed_properties/computers.py
@@ -7,12 +7,12 @@ from skills_ml.algorithms.occupation_classifiers.classifiers import \
     SocClassifier
 from skills_ml.job_postings.corpora import SimpleCorpusCreator
 import logging
+import statistics
 
 
 NUMERIC_AGGREGATION_FUNCTION_PATHS = {
     'numpy.mean': 'Arithemetic mean',
     'numpy.median': 'Median (middle value)',
-    'statistics.mode': 'Mode (most common value)',
     'numpy.std': 'Sample standard deviation',
     'numpy.var': 'Sample variance',
 }
@@ -180,7 +180,7 @@ class HourlyPay(JobPostingComputedProperty, PayMixin):
 
     def _compute_func_on_one(self):
         def func(job_posting):
-            if job_posting.get('baseSalary', {}).get('salaryFrequency', None) is not 'hourly':
+            if job_posting.get('baseSalary', {}).get('salaryFrequency', None) != 'hourly':
                 return None
             return self.salary_from_job_posting(job_posting)
         return func
@@ -199,7 +199,7 @@ class YearlyPay(JobPostingComputedProperty, PayMixin):
 
     def _compute_func_on_one(self):
         def func(job_posting):
-            if job_posting.get('baseSalary', {}).get('salaryFrequency', None) is not 'yearly':
+            if job_posting.get('baseSalary', {}).get('salaryFrequency', None) != 'yearly':
                 return None
             return self.salary_from_job_posting(job_posting)
         return func

--- a/tests/job_postings/test_computed_properties.py
+++ b/tests/job_postings/test_computed_properties.py
@@ -222,12 +222,17 @@ class YearlyPayTest(ComputedPropertyTestCase):
         self.storage = S3Store('s3://test-bucket/computed_properties')
         self.computed_property = YearlyPay(self.storage)
         self.job_postings = [utils.job_posting_factory(
+            id=5,
             datePosted=self.datestring,
             baseSalary={'salaryFrequency': 'yearly', 'minValue': 5, 'maxValue': ''}
-        ),]
+        ), utils.job_posting_factory(
+            id=6,
+            datePosted=self.datestring,
+            baseSalary={'salaryFrequency': 'yearly', 'minValue': '6.25', 'maxValue': '9.25'}
+        )]
         self.computed_property.compute_on_collection(self.job_postings)
 
     def test_compute_func(self):
         cache = self.computed_property.cache_for_key(self.datestring)
-        job_posting_id = self.job_postings[0]['id']
-        assert cache[str(job_posting_id)] == 5
+        assert cache[str(self.job_postings[0]['id'])] == 5
+        assert cache[str(self.job_postings[1]['id'])] == 7.75


### PR DESCRIPTION
1. Turns out we needed the statistics import for the mean call
2. Test didn't catch it because it only comes up if we have both min and max value for a wage, hence we needed a test that had both
3. statistics.mode broke in the test where there wasn't a distinct mode, I was going to replace it with the n_most_cmmon that we use for skills and SOC codes but honestly I don't think mode makes sense for this continuous data so I just took it out as a whitelisted metric.