### PR TITLE
Evaluate CandidateSkills against another set [Resolves #218]

### DIFF
--- a/skills_ml/algorithms/skill_extractors/base.py
+++ b/skills_ml/algorithms/skill_extractors/base.py
@@ -85,6 +85,7 @@ CandidateSkill = namedtuple('CandidateSkill', [
     'skill_name',
     'matched_skill_identifier',
     'context',
+    'start_index',
     'confidence',
     'document_id',
     'document_type',

--- a/skills_ml/algorithms/skill_extractors/exact_match.py
+++ b/skills_ml/algorithms/skill_extractors/exact_match.py
@@ -64,17 +64,20 @@ class ExactMatchSkillExtractor(ListBasedSkillExtractor):
         """
         document = self.transform_func(source_object)
         sentences = self.nlp.sentence_tokenize(document)
+        sentence_start = 0
         for sent in sentences:
-            matches = self.lookup_regex.findall(sent)
+            matches = self.lookup_regex.finditer(sent)
             for match in matches: 
                 logging.info('Yielding exact match %s in string %s', match, sent)
                 yield CandidateSkill(
-                    skill_name=match.lower(),
-                    matched_skill_identifier=self.id_lookup[match.lower()],
+                    skill_name=match[0].lower(),
+                    matched_skill_identifier=self.id_lookup[match[0].lower()],
                     confidence=100,
                     context=sent,
+                    start_index=sentence_start + match.start(),
                     document_id=source_object['id'],
                     document_type=source_object['@type'],
                     source_object=source_object,
                     skill_extractor_name=self.name
                 )
+            sentence_start += len(sent)

--- a/skills_ml/algorithms/skill_extractors/fuzzy_match.py
+++ b/skills_ml/algorithms/skill_extractors/fuzzy_match.py
@@ -79,10 +79,12 @@ class FuzzyMatchSkillExtractor(ListBasedSkillExtractor):
     def candidate_skills(self, source_object: Dict) -> CandidateSkillYielder:
         document = self.transform_func(source_object)
         sentences = self.nlp.sentence_tokenize(document)
+        phrase_start = 0
 
         for sent in sentences:
             for phrase in self.ngrams(sent, self.max_ngrams):
                 length_of_phrase = len(phrase)
+                phrase_start += length_of_phrase
                 max_distance = length_of_phrase - \
                     ceil(length_of_phrase * self.match_threshold/100)
                 if max_distance > self.max_distance:
@@ -100,6 +102,7 @@ class FuzzyMatchSkillExtractor(ListBasedSkillExtractor):
                         matched_skill_identifier=self.id_lookup[match.term],
                         confidence=100*(length_of_phrase-match.distance)/length_of_phrase,
                         context=sent,
+                        start_index=phrase_start,
                         document_id=source_object['id'],
                         document_type=source_object['@type'],
                         source_object=source_object,

--- a/skills_ml/evaluation/skill_extraction_metrics.py
+++ b/skills_ml/evaluation/skill_extraction_metrics.py
@@ -144,3 +144,85 @@ class TotalOccurrences(SkillExtractorMetric):
 
     def eval(self, candidate_skills: CandidateSkillYielder, sample_len: int) -> int:
         return sum(1 for candidate_skill in candidate_skills)
+
+
+strict_candidate_key = lambda cs: (cs.document_id, cs.document_type, cs.skill_name, cs.start_index)
+nonstrict_candidate_key = lambda cs: (cs.document_id, cs.document_type, cs.skill_name)
+
+class EvaluationSetPrecision(SkillExtractorMetric):
+    """Find the precision evaluated against an evaluation set of candidate skills.
+
+    Args:
+    candidate_skills (CandidateSkillYielder): A collection of candidate skills to evaluate against
+    evaluation_set_name (str): A name for the evaluation set of candidate skills.
+        Used in the name of the metric so results from multiple evaluation sets
+        can be compared side-by-side.
+    strict (bool, default True): Whether or not to enforce the exact location of the match,
+        versus just matching between sets on the same skill name and document.
+        Setting this to False will guard against:
+            1. labelers who don't mark every instance of a skill once they found one instance
+            2. discrepancies in start_index values caused by errant transformation methods 
+        However, this could also produce false matches, so use with care.
+    """
+
+    @property
+    def name(self):
+        strictstring = 'strict' if self.strict else 'nonstrict'
+        return f'{self.evaluation_set_name}_evaluation_set_precision_{strictstring}'
+
+    def __init__(
+        self,
+        candidate_skills: CandidateSkillYielder,
+        evaluation_set_name: str,
+        strict: bool=True
+    ):
+        self.strict = strict
+        self.keyfunc = strict_candidate_key if strict else nonstrict_candidate_key
+        self.gold_standard_candidate_skills = set(self.keyfunc(candidate_skill) for candidate_skill in candidate_skills)
+        self.evaluation_set_name = evaluation_set_name
+
+    def eval(self, candidate_skills: CandidateSkillYielder, sample_len: int) -> int:
+        num_candidates_in_gs = 0
+        total_candidates = 0
+        for candidate_skill in candidate_skills:
+            total_candidates += 1
+            if self.keyfunc(candidate_skill) in self.gold_standard_candidate_skills:
+                num_candidates_in_gs += 1
+        return float(num_candidates_in_gs) / total_candidates
+
+
+class EvaluationSetRecall(SkillExtractorMetric):
+    """Find the recall evaluated against an evaluation set of candidate skills.
+
+    Args:
+    candidate_skills (CandidateSkillYielder): A collection of candidate skills to evaluate against
+    evaluation_set_name (str): A name for the evaluation set of candidate skills.
+        Used in the name of the metric so results from multiple evaluation sets
+        can be compared side-by-side.
+    strict (bool, default True): Whether or not to enforce the exact location of the match,
+        versus just matching between sets on the same skill name and document.
+        Setting this to False will guard against:
+            1. labelers who don't mark every instance of a skill once they found one instance
+            2. discrepancies in start_index values caused by errant transformation methods 
+        However, this could also produce false matches, so use with care.
+    """
+
+    @property
+    def name(self):
+        strictstring = 'strict' if self.strict else 'nonstrict'
+        return f'{self.evaluation_set_name}_evaluation_set_recall_{strictstring}'
+
+    def __init__(self, candidate_skills, evaluation_set_name, strict=True):
+        self.strict = strict
+        self.keyfunc = strict_candidate_key if strict else nonstrict_candidate_key
+        self.gold_standard_candidate_skills = set(self.keyfunc(candidate_skill) for candidate_skill in candidate_skills)
+        self.evaluation_set_name = evaluation_set_name
+
+    def eval(self, candidate_skills: CandidateSkillYielder, sample_len: int) -> int:
+        found_candidate_skills = set(self.keyfunc(candidate_skill) for candidate_skill in candidate_skills)
+
+        num_candidates_found = 0
+        for cs in self.gold_standard_candidate_skills:
+            if cs in found_candidate_skills:
+                num_candidates_found += 1
+        return float(num_candidates_found) / len(self.gold_standard_candidate_skills)

--- a/skills_ml/storage/__init__.py
+++ b/skills_ml/storage/__init__.py
@@ -145,6 +145,18 @@ class InMemoryStore(Store):
         return [key for key in self.store if key.startswith(subpath)]
 
 
+def store_from_path(path):
+    path_parsed = urlparse(path)
+    scheme = path_parsed.scheme
+
+    if not scheme or scheme == 'file':
+        return FSStore(path)
+    elif scheme == 's3':
+        return S3Store(path)
+    elif scheme == 'memory':
+        return InMemoryStore(path)
+
+
 class PersistedJSONDict(MutableMapping):
 
     SAVE_EVERY_N_UPDATES = 1000

--- a/tests/algorithms/skill_extractors/test_exact_match.py
+++ b/tests/algorithms/skill_extractors/test_exact_match.py
@@ -46,8 +46,10 @@ def test_exactmatch_skill_extractor_candidate_skills():
     assert candidate_skills[0].matched_skill_identifier == 'c'
     assert candidate_skills[0].context == 'One-two years cooking experience in a professional kitchen'
     assert candidate_skills[0].confidence == 100
+    assert candidate_skills[0].start_index == 164
 
     assert candidate_skills[1].skill_name == 'organization'
     assert candidate_skills[1].matched_skill_identifier == 'a'
     assert candidate_skills[1].context == 'Organization, Cleanliness, Trainability, team player, good communication skillz, Motivation, a Sense of Responsibility and Pride in your Performance'
     assert candidate_skills[1].confidence == 100
+    assert candidate_skills[1].start_index == 430

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,6 +31,7 @@ class CandidateSkillFactory(factory.Factory):
     skill_name = factory.fuzzy.FuzzyText()
     matched_skill_identifier = factory.fuzzy.FuzzyText()
     context = factory.LazyAttribute(lambda obj: f"{factory.fuzzy.FuzzyText()}{obj.skill_name}{factory.fuzzy.FuzzyText()}")
+    start_index = factory.fuzzy.FuzzyInteger(0, 100)
     confidence = factory.fuzzy.FuzzyFloat(0, 1)
     document_id = factory.fuzzy.FuzzyText()
     document_type = '@JobPosting',


### PR DESCRIPTION
Adding support for evaluation of a skill extractor's output (as in, a
set of Candidate Skills) against an evaluation set, with basic precision
and recall metrics.

The evaluation set is generally understood to be a gold standard human labeled set, from an
annotation tool such as BRAT. However, it's not limited to this: You can
use this to compare any two lists of CandidateSkills: Two
automatically generated sets, two human labeled sets, or use an
automatically generated one to evaluate a human labeled one.

To make this useful, bindings are introduced to the BratExperiment
object to output CandidateSkills. This replaces the
labels_with_agreement method that was very similar in scope to
CandidateSkills, but so far unused.

To enable this change, the start_index was introduced to the
CandidateSkill. This allows for comparing the location of the skill name
in two CandidateSkills. However, a nonstrict mode is introduced to this
metric to allow evaluation if there is some accidental discrepancy
between indices of the two sets of CandidateSkills, as in some
aggressive tokenization or string cleaning. This nonstrict mode is also
useful if one wants to account for human labelers not diligently tagging
every occurrence of a skill name in a job posting, or even just
providing a broader picture of skill extraction effectiveness.