### PR TITLE
Print Ontology Stats

### DIFF
--- a/skills_ml/ontologies/base.py
+++ b/skills_ml/ontologies/base.py
@@ -389,21 +389,28 @@ class CompetencyOntology(object):
     @property
     def occupation_counts_per_competency(self):
         counts = []
-        for k, g in itertools.groupby(
-            sorted(self.edges, key=lambda edge: edge.competency),
+        for competency, edges in itertools.groupby(
+            sorted(self._competency_occupation_edges, key=lambda edge: edge.competency),
             lambda edge: edge.competency
         ):
-            counts.append(len(set([edge.occupation for edge in list(g)])))
+            if competency != DummyCompetency():
+                counts.append(len(set([
+                    edge.occupation for edge in list(edges) if edge.occupation != DummyOccupation()
+                ])))
         return counts
 
     @property
     def competency_counts_per_occupation(self):
         counts = []
-        for k, g in itertools.groupby(
-            sorted(self.edges, key=lambda edge: edge.occupation),
+        for occupation, edges in itertools.groupby(
+            sorted(self._competency_occupation_edges, key=lambda edge: edge.occupation),
             lambda edge: edge.occupation
         ):
-            counts.append(len(set([edge.competency for edge in list(g)])))
+            if occupation != DummyOccupation():
+                counts.append(len(set([
+                    edge.competency for edge in list(edges)
+                    if edge.competency != DummyCompetency()
+                ])))
         return counts
 
     def print_summary_stats(self):

--- a/skills_ml/ontologies/base.py
+++ b/skills_ml/ontologies/base.py
@@ -1,8 +1,12 @@
 from typing import Callable, Text, List
 from collections import MutableMapping
 import json
+from statistics import median
+from functools import total_ordering
+import itertools
 
 
+@total_ordering
 class Competency(object):
     """Represents a competency not necessarily tied to an ontology
 
@@ -36,8 +40,14 @@ class Competency(object):
         return obj
 
     def __eq__(self, other):
-        if isinstance(self, other.__class__):
-            return self.identifier == other.identifier
+        if not isinstance(self, other.__class__):
+            return NotImplemented
+        return self.identifier == other.identifier
+
+    def __lt__(self, other):
+        if not isinstance(self, other.__class__):
+            return NotImplemented
+        return self.identifier < other.identifier
 
     def __hash__(self):
         return hash(self.identifier)
@@ -81,6 +91,7 @@ class Competency(object):
             parent.add_child(self)
 
 
+@total_ordering
 class Occupation(object):
     """Represents an occupation that may or may not be part of an ontology
     
@@ -111,8 +122,14 @@ class Occupation(object):
         return obj
 
     def __eq__(self, other):
-        if isinstance(self, other.__class__):
-            return self.identifier == other.identifier
+        if not isinstance(self, other.__class__):
+            return NotImplemented
+        return self.identifier == other.identifier
+
+    def __lt__(self, other):
+        if not isinstance(self, other.__class__):
+            return NotImplemented
+        return self.identifier < other.identifier
 
     def __hash__(self):
         return hash(self.identifier)
@@ -273,7 +290,7 @@ class CompetencyOntology(object):
     @classmethod
     def from_jsonld(cls, jsonld_string: Text):
         jsonld_input = json.loads(jsonld_string)
-        obj = cls()
+        obj = cls(name=jsonld_input.get('name', 'unnamed ontology'))
         for competency_jsonld in jsonld_input['competencies']:
             obj.add_competency(Competency.from_jsonld(competency_jsonld))
         for occupation_jsonld in jsonld_input['occupations']:
@@ -351,6 +368,7 @@ class CompetencyOntology(object):
     @property
     def jsonld(self):
         return json.dumps({
+            'name': self.name,
             'competencies': [
                 competency.jsonld_full
                 for competency in
@@ -367,3 +385,31 @@ class CompetencyOntology(object):
                 sorted(self.edges, key=lambda edge: edge.identifier)
             ]
         }, sort_keys=True)
+
+    @property
+    def occupation_counts_per_competency(self):
+        counts = []
+        for k, g in itertools.groupby(
+            sorted(self.edges, key=lambda edge: edge.competency),
+            lambda edge: edge.competency
+        ):
+            counts.append(len(set([edge.occupation for edge in list(g)])))
+        return counts
+
+    @property
+    def competency_counts_per_occupation(self):
+        counts = []
+        for k, g in itertools.groupby(
+            sorted(self.edges, key=lambda edge: edge.occupation),
+            lambda edge: edge.occupation
+        ):
+            counts.append(len(set([edge.competency for edge in list(g)])))
+        return counts
+
+    def print_summary_stats(self):
+        print(f'Ontology summary statistics for {self.name}')
+        print(f'Num competencies: {len(self.competency_framework)}')
+        print(f'Num occupations: {len(self.occupations)}')
+        print(f'Num competency-occupation edges: {len(self.edges)}')
+        print(f'Median occupations per competency: {median(self.occupation_counts_per_competency)}')
+        print(f'Median competencies per occupation: {median(self.competency_counts_per_occupation)}')

--- a/skills_ml/ontologies/onet.py
+++ b/skills_ml/ontologies/onet.py
@@ -70,15 +70,16 @@ class Onet(CompetencyOntology):
             logging.info('Processing Knowledge, Skills, Abilities')
             for content_model_file in {'Knowledge', 'Abilities', 'Skills'}:
                 for row in onet_cache.reader(content_model_file):
-                    competency = Competency(
-                        identifier=row['Element ID'],
-                        name=row['Element Name'],
-                        categories=[content_model_file],
-                        competencyText=description_lookup[row['Element ID']]
-                    )
-                    self.add_competency(competency)
-                    occupation = Occupation(identifier=row['O*NET-SOC Code'])
-                    self.add_edge(competency=competency, occupation=occupation)
+                    if row['Scale ID'] == 'IM' and float(row['Data Value']) >= 3:
+                        competency = Competency(
+                            identifier=row['Element ID'],
+                            name=row['Element Name'],
+                            categories=[content_model_file],
+                            competencyText=description_lookup[row['Element ID']]
+                        )
+                        self.add_competency(competency)
+                        occupation = Occupation(identifier=row['O*NET-SOC Code'])
+                        self.add_edge(competency=competency, occupation=occupation)
 
             logging.info('Processing tools and technology')
             for row in onet_cache.reader('Tools and Technology'):

--- a/tests/ontologies/test_base.py
+++ b/tests/ontologies/test_base.py
@@ -337,3 +337,9 @@ class OntologyTest(TestCase):
 
     def test_import_from_jsonld(self):
         assert CompetencyOntology.from_jsonld(self.jsonld()) == self.ontology()
+
+    def test_competency_counts_per_occupation(self):
+        assert sorted(self.ontology().competency_counts_per_occupation) == [2]
+
+    def test_occupation_counts_per_competency(self):
+        assert sorted(self.ontology().occupation_counts_per_competency) == [0, 0, 1, 1]

--- a/tests/ontologies/test_base.py
+++ b/tests/ontologies/test_base.py
@@ -244,7 +244,7 @@ class OntologyTest(TestCase):
         assert civil_engineer_ontology.occupations == {civil_engineer}
 
     def ontology(self):
-        ontology = CompetencyOntology()
+        ontology = CompetencyOntology(name='Test Ontology')
         comm = Competency(identifier='123', name='communication', categories=['social skills'])
         python = Competency(identifier='999', name='python', categories=['Technologies'])
         math = Competency(identifier='111', name='mathematics', categories=['Knowledge'])
@@ -262,6 +262,7 @@ class OntologyTest(TestCase):
 
     def jsonld(self):
         return json.dumps({
+            'name': 'Test Ontology',
             'occupations': [{
                 '@type': 'Occupation',
                 '@id': '123',

--- a/tests/ontologies/test_base.py
+++ b/tests/ontologies/test_base.py
@@ -343,3 +343,8 @@ class OntologyTest(TestCase):
 
     def test_occupation_counts_per_competency(self):
         assert sorted(self.ontology().occupation_counts_per_competency) == [0, 0, 1, 1]
+
+    def test_print_summary(self):
+        # literally just want to make sure that this function doesn't error out
+        # due to bad interpolation or something. no asserts
+        self.ontology().print_summary_stats()


### PR DESCRIPTION
Adds a print_summary_stats() method to the ontology class. In the
printing of these summary stats on ONET, some oddities were found with both the base class and the ONET loader that have been fixed here.

- Ontology name was not included in the serialized version, so if you
wrote and then loaded one it would lose the name
- ONET loader was being too permissive with regards to competency-occupation
edges. It was adding an edge for each line in the file (IM and LV),
which not only duplicated edges but also would add irrelevant edges
along with relevant ones. So instead, the loader only adds
competency-occupation edges from the IM (importance) row, and only if the importance
level is 3 or above. How was this arrived at? ONET's guidelines on the
site. Competencies are only rated as 'important' to the occupation and
displayed if they pass this threshold. This seems like a reasonable
guideline for our mapping.
- Base Competency and Occupation classes were not comparable. Added a
__lt__ and functools.total_ordering to allow a user to sort and group by
Competency and Occupation objects.