### PR TITLE
Create CompetencyOntology from CandidateSkills [Resolves #148]

### DIFF
--- a/docs/sources/ontologies.md
+++ b/docs/sources/ontologies.md
@@ -233,6 +233,11 @@ ontology = CompetencyOntology.from_jsonld({
 })
 ```
 
+## Creating CompetencyOntology from CandidateSkills
+
+To evaluate a method of skill extraction, it can be useful to format the output (a collection of CandidateSkill objects) as a CompetencyOntology. Importing `skills_ml.ontologies.from_candidate_skills.ontology_from_candidate_skills` enables this conversion. At present, the `ontology_from_candidate_skills` simply adds each of the found competencies to a bare ontology, and optionally associates them with the source object's occupation if tagged with one.
+
+
 ## Included Ontologies
 
 ### ONET

--- a/skills_ml/ontologies/from_candidate_skills.py
+++ b/skills_ml/ontologies/from_candidate_skills.py
@@ -1,0 +1,39 @@
+from collections import defaultdict
+
+from skills_ml.ontologies.base import Competency, Occupation, CompetencyOntology
+from skills_ml.algorithms.skill_extractors.base import CandidateSkillYielder
+from skills_ml.job_postings.common_schema import get_onet_occupation
+
+
+def ontology_from_candidate_skills(candidate_skills: CandidateSkillYielder, skill_extractor_name: str='unknown') -> CompetencyOntology:
+    """Create an ontology from a list of candidate skills
+
+    Simply associate each candidate skill with its ONET occupation.
+
+    Args:
+        candidate_skills (iterable of algorithms.skill_extractors.base.CandidateSkill objects)
+
+    Returns: (skills_ml.ontologies.base.CompetencyOntology)
+    """
+    ontology = CompetencyOntology(
+        name=f'candidate_skill_{skill_extractor_name}',
+        competency_name=f'candidate_skill_{skill_extractor_name}',
+        competency_description=f'Constructed from CandidateSkill objects produced by the {skill_extractor_name} skill extractor'
+    )
+    competencies_by_document_id = defaultdict(set)
+    for candidate_skill in candidate_skills:
+        competency = Competency(
+            identifier=candidate_skill.skill_name.lower(),
+            name=candidate_skill.skill_name
+        )
+        if competency not in competencies_by_document_id[candidate_skill.document_id]:
+            competencies_by_document_id[candidate_skill.document_id].add(competency)
+        if competency not in ontology.competencies:
+            ontology.add_competency(competency)
+        occupation_code = get_onet_occupation(candidate_skill.source_object)
+        occupation = Occupation(identifier=occupation_code)
+        if occupation not in ontology.occupations:
+            ontology.add_occupation(occupation)
+        ontology.add_edge(occupation=occupation, competency=competency)
+
+    return ontology

--- a/tests/ontologies/test_from_candidate_skills.py
+++ b/tests/ontologies/test_from_candidate_skills.py
@@ -1,0 +1,22 @@
+from tests.utils import CandidateSkillFactory
+from skills_ml.ontologies.from_candidate_skills import ontology_from_candidate_skills
+
+
+def test_ontology_from_candidate_skills():
+    candidate_skills = [CandidateSkillFactory(skill_name=f'skill_{i}') for i in range(0, 25)]
+    ontology = ontology_from_candidate_skills(candidate_skills, skill_extractor_name='tester')
+    assert ontology.name == 'candidate_skill_tester'
+    assert ontology.competency_framework.name == 'candidate_skill_tester'
+    assert 'tester' in ontology.competency_framework.description
+    assert len(ontology.competencies) == 25
+    assert len(ontology.occupations) == 1
+
+
+def test_ontology_from_candidate_skills_occupations():
+    candidate_skills = [CandidateSkillFactory(
+        skill_name=f'skill_{i}',
+        source_object={'onet_soc_code': f'11-101{i%5}.00'}
+    ) for i in range(0, 25)]
+    ontology = ontology_from_candidate_skills(candidate_skills)
+    assert len(ontology.competencies) == 25
+    assert len(ontology.occupations) == 5


### PR DESCRIPTION
Depending on the method of producing candidate skills, it may be
desirable to create a CompetencyOntology from the candidate skills for
further analysis. Some use cases:

1. the method of producing candidate skills
may produce a very high signal vocabulary with low recall that is a
candidate for more standard exact matching.
2. Comparing this ontology with pre-defined ontologies

- Add ontology_from_candidate_skills which creates a CompetencyOntology from a
list of candidate skills