### PR TITLE
Section Extract Fixes

### DIFF
--- a/skills_ml/algorithms/string_cleaners/nlp.py
+++ b/skills_ml/algorithms/string_cleaners/nlp.py
@@ -115,11 +115,7 @@ def sentence_tokenize(text: str) -> List[str]:
     """
     sentences = re.split('\n', text)
     sentences = list(filter(None, sentences))
-    try:
-        sentences = reduce(lambda x, y: x+y, map(lambda x: nltk.sent_tokenize(x), sentences.encode('utf-8')))
-    except:
-        sentences = reduce(lambda x, y: x+y, map(lambda x: nltk.sent_tokenize(x), sentences))
-    return sentences
+    return reduce(lambda x, y: x+y, map(lambda x: nltk.sent_tokenize(x), sentences))
 
 @deep
 def word_tokenize(text: str, punctuation=True) -> List[str]:
@@ -187,6 +183,8 @@ def section_extract(section_regex: Pattern, document: str) -> List:
     sentence tokenization insufficient if the newlines have been taken out.
     """
     units_in_section = []
+    if not document:
+        return units_in_section
     sentences = sentence_tokenize(document)
     units = [
         unit
@@ -200,7 +198,7 @@ def section_extract(section_regex: Pattern, document: str) -> List:
         if unit.strip() and unit[0] not in BULLET_CHARACTERS and ((words_in_unit > 0 and words_in_unit < 4) or unit.endswith(':')):
             heading = unit
         if re.match(section_regex, heading) and unit != heading and len(unit.strip()) > 0:
-            units_in_section.append(unit.lstrip().rstrip())
+            units_in_section.append(strip_bullets_from_line(unit).lstrip().rstrip())
     return units_in_section
 
 

--- a/tests/algorithms/test_string_cleaners.py
+++ b/tests/algorithms/test_string_cleaners.py
@@ -28,22 +28,17 @@ class TestStringCleaners(unittest.TestCase):
     def test_section_extract(self):
         document = "1st Assistant Golf Professional\n\n\n\nAll times are in Coordinated Universal Time.\n\nRequisition ID\n\n2017-14328\n\n# of Openings\n\n1\n\nJob Locations\n\nUS-TX-Austin\n\nPosted Date\n\n3/27/2017\n\nCategory (Portal Searching)\n\nGolf Resort Operations\n\n\n\n\n\nMore information about this job:\n\n\n\n\n\nLocation:\n\n\n\n\n\n\n\n**Barton Creek Resort & Spa**\n\n\n\n[Barton Creek]\n\n\n\nBarton Creek Resort & Spa's success is due to its dedicated, intelligent and self-motivated family of associates who work together to maintain the company's trademark high standards. If you would like to be a part of an environment where teamwork is emphasized and individual excellence is encouraged then this is the place for you.\n\n\n\nOmni Barton Creek Resort and Spa\u2019s associates enjoy a dynamic and exciting work environment, comprehensive training and mentoring, along with the pride that comes from working for a company with a reputation for exceptional service. We embody a culture of respect, gratitude and empowerment day in and day out. If you are a friendly, motivated person, with a passion to serve others, the Omni Barton Creek may be your perfect match.\n\n\n\n\n\nJob Description:\n\n\n\n\n\nThe 1st Assistant Golf Professional will assist the First Assistant and the Head Golf Professional with all activities relating to the management and execution of the properties golf operations, including but not limited to Member tournaments, Resort and outside events, outside service staff, golf shop, practice facilities, instructional program, financial management, human resource management and maintenance of golf equipment.\n\n\n\n****\n\n\n\n\n\nResponsibilities:\n\n\n\n\n\n\n\n* Ensure that all members and guests are greeted and welcomed in a professional and courteous manner.\n\n* Answer telephones to schedule future starting times and communicate information in a pleasant and professional manner.\n\n* Maintain inventory control and cash bank.\n\n* Ensure the golf course is properly marked.\n\n* Professionally communicate information, sell merchandise, and become fully knowledgeable in all products in the golf shop. Anticipate the needs of members and guests to offer appropriate merchandise alternatives.\n\n* Assist with physical inventories, as prescribed by Director of Retail and Head Golf Professional.\n\n* Ensure the \u201cpace of play\u201d standard is maintained daily.\n\n* Oversee rental club inventory.\n\n\n\n\n\n\n\n\n\n\n\nQualifications:\n\n\n\n\n\n\n\n* Excellent communication skills, both verbal and written\n\n* Solid computer skills including Microsoft Outlook, Word, and Excel\n\n* Proven leadership\n\n* Reputation for quality and attention to detail\n\n* Ability and willingness to work long hours and weekends as demanded by business cycles\n\n* Ability to use logical and rational thinking to solve problems.\n\n* Flexibility in hours, ability to manage multiple tasks"
         expected_section_units = [
-            "* Excellent communication skills, both verbal and written",
-            "* Solid computer skills including Microsoft Outlook, Word, and Excel",
-            "* Proven leadership",
-            "* Reputation for quality and attention to detail",
-            "* Ability and willingness to work long hours and weekends as demanded by business cycles",
-            "* Ability to use logical and rational thinking to solve problems.",
-            "* Flexibility in hours, ability to manage multiple tasks"
+            "Excellent communication skills, both verbal and written",
+            "Solid computer skills including Microsoft Outlook, Word, and Excel",
+            "Proven leadership",
+            "Reputation for quality and attention to detail",
+            "Ability and willingness to work long hours and weekends as demanded by business cycles",
+            "Ability to use logical and rational thinking to solve problems.",
+            "Flexibility in hours, ability to manage multiple tasks"
         ]
 
         section_units = section_extract(section_regex=r'.*Qualifications', document=document)
         assert section_units == expected_section_units
-        #tokenized = TextTilingTokenizer().tokenize(document)
-        #for token in tokenized:
-            #print(token)
-        #assert False
         document = document.replace('\n', ' ')
         section_units = section_extract(section_regex=r'.*Qualifications', document=document)
-        print(section_units)
         assert section_units == expected_section_units


### PR DESCRIPTION
In running the section extract skill extractor at scale, a couple of
problems were noticed:

- The encoding exception catch block in sentence_tokenize is always hit
- Empty strings break it entirely

Further experimenting with the encoding reveals that
nltk.sentence_tokenize seems to need a string, so I don't think we
should try and encode it at all.

Also, the section_extract had some oddities: it didn't remove any
bullets from returned sections. This is a very minor problem but
removing the bullets does improve the readability of the results

Fixes:

- Add empty document check for section_extract
- Remove encoding block in sentence_tokenize
- Remove bullets from section_extract output
- Remove commented out code in section extract test