### PR TITLE
Improve Export/Import of Ontology [Resolves #232]

### DIFF
--- a/docs/sources/ontologies.md
+++ b/docs/sources/ontologies.md
@@ -205,7 +205,8 @@ ontology.add_edge(occupation=dinosaur_rider, competency=dinosaur_riding)
 ```python
 from skills_ml.ontologies import CompetencyOntology
 
-ontology = CompetencyOntology.from_jsonld({
+jsonld_string = """
+    'name': 'test_ontology',
 	'competencies': [{
 		'@type': 'Competency',
 		'@id': '12345',
@@ -230,14 +231,37 @@ ontology = CompetencyOntology.from_jsonld({
 		'competency': {'@type': 'Competency', '@id': '12345'},
 		'occupation': {'@type': 'Occupation', '@id': '9999'}
 	}]
-})
+}"""
+
+ontology = CompetencyOntology(jsonld_string=jsonld_string)
+```
+
+*Using URL*
+
+If you have access to a URL that contains compatible JSON-LD, you can send this URL right to the constructor.
+
+```python
+
+ontology = CompetencyOntology(url='https://myhost.com/ontology.json')
+
+```
+
+*Using Research Hub*
+
+The Data@Work Research Hub hosts a number of ontologies publicly. The Research Hub ontology base URL is bundled into Skills-ML, so you can also just initialize one with the saved name on the Research Hub.
+
+You can view the list of available ontologies at the [Research Hub](http://dataatwork.org/data/research/?prefix=v3/ontologies/)
+
+```python
+
+ontology = CompetencyOntology(research_hub_name='esco')
 ```
 
 ## Included Ontologies
 
 ### ONET
 
-The `skills_ml.ontologies.onet` module contains a Onet class inherited from CompetencyOntology which will build the ontology during the instantiation from a variety of files on the ONET site, using at the time of writing the latest version of onet (db_v22_3):
+The `skills_ml.ontologies.onet` module contains a Onet class inherited from CompetencyOntology. This class can be built either from a hosted JSON-LD file on the Research Hub, or by default will build the ontology during the instantiation from a variety of files on the ONET site, using at the time of writing the latest version of onet (db_v22_3):
 
 - Content Model Reference.txt
 - Knowledge.txt
@@ -263,6 +287,23 @@ from skills_ml.datasets.onet_cache import OnetSiteCache
 from skills_ml.ontologies.onet import Onet
 
 ONET = Onet(OnetSiteCache(FSStore('onet_cache')))
+```
+
+To build from the research hub, pass `manual_build=False`. This may be slightly quicker, and will be resilient to potential changes to the ONET site format.
+
+```python
+ONET = Onet(manual_build=False)
+```
+
+### ESCO
+
+The `skills_ml.ontologies.esco` module contains an Esco class inherited from CompetencyOntology that implements the European Skills and Competences and Occupations site. This class by default is built from a hosted JSON-LD file on the Research Hub, but you can also have it build right from the ESCO site. Building right from the ESCO site involves thousands of API calls, so we recommend building it from the Research Hub JSON-LD
+
+
+```python
+from skills_ml.ontologies.esco import Esco
+ESCO = Esco() # will build from premade Research Hub JSON-LD
+ESCO = Esco(manual_build=True) # will build from ESCO site, may take hours
 ```
 
 

--- a/skills_ml/ontologies/__init__.py
+++ b/skills_ml/ontologies/__init__.py
@@ -1,9 +1,10 @@
-from .base import Competency, Occupation, CompetencyOccupationEdge, CompetencyOntology, CompetencyFramework
+from .base import Competency, Occupation, CompetencyOccupationEdge, CompetencyOntology, CompetencyFramework, research_hub_url
 
 __all__ = (
     'Competency',
     'CompetencyFramework',
     'Occupation',
     'CompetencyOccupationEdge',
-    'CompetencyOntology'
+    'CompetencyOntology',
+    'research_hub_url'
 )

--- a/skills_ml/ontologies/base.py
+++ b/skills_ml/ontologies/base.py
@@ -4,6 +4,12 @@ import json
 from statistics import median
 from functools import total_ordering
 import itertools
+import requests
+
+
+def research_hub_url(name: Text) -> Text:
+    """Retrieve the current Research Hub URL for ontologies"""
+    return 'https://open-skills-datasets.s3-us-west-2.amazonaws.com/v3/ontologies/' + name + '.json'
 
 
 @total_ordering
@@ -236,70 +242,102 @@ class CompetencyFramework(MutableMapping):
     def __init__(self, name=None, description=None, competencies=None):
         self.name = name or ''
         self.description = description or ''
-        self.competencies = {}
-        for competency in competencies or []:
-            self.competencies[competency.identifier] = competency
+        self._competencies = dict()
+        if competencies:
+            self.competencies = competencies
 
     def __setitem__(self, key, value):
-        self.competencies[key] = value
+        self._competencies[key] = value
 
     def __getitem__(self, key):
-        return self.competencies[key]
+        return self._competencies[key]
 
     def __delitem__(self, key):
-        del self.competencies[key]
+        del self._competencies[key]
 
     def __iter__(self):
-        return iter(self.competencies)
+        return iter(self._competencies)
 
     def __len__(self):
-        return len(self.competencies)
+        return len(self._competencies)
 
     def add(self, value):
-        if value.identifier in self.competencies:
+        if value.identifier in self._competencies:
             raise ValueError(f"{value} already in framework")
-        self.competencies[value.identifier] = value
+        self._competencies[value.identifier] = value
+
+    @property
+    def competencies(self):
+        return self._competencies
+
+    @competencies.setter
+    def competencies(self, competencies):
+        for competency in competencies:
+            self._competencies[competency.identifier] = competency
         
 
 class CompetencyOntology(object):
-    """An ontology of competencies and occupations and the edges between them
+    """An ontology of competencies and occupations (each referred to as nodes) and the edges between them
     
-    Can be initialized with a set of edges, in which case the competencies and occupations will be initialized with any that are present in the edge list
+    Can be initialized with:
+        - a JSON-LD string, in which case all nodes and edges will be initialized from the parsed JSON-LD
+        - a URL, in which case the URL is presumed to contain JSON-LD, parsed, and all nodes and edges will be initialized from the parsed JSON-LD
+        - a research hub name, in which case the Open Skills Research Hub is presumed to host an ontology by that name. a URL is built based on the name and the nodes and edges will be initialized from the parsed JSON-LD
+        - a set of edges, in which case all nodes will be initialized with any that are present in the edge list
     """
     name = 'unnamed_ontology'
 
-    def __init__(self, edges=None, name=None, competency_name=None, competency_description=None):
-        if name:
-            self.name = name
-        if edges:
-            self._competency_occupation_edges = edges
-            self.competency_framework = CompetencyFramework(
-                name=competency_name,
-                description=competency_description,
-                competencies=[edge.competency for edge in edges]
-            )
-            self._occupations = dict((edge.occupation.identifier, edge.occupation) for edge in edges)
-        else:
-            self.competency_framework = CompetencyFramework(
-                name=competency_name,
-                description=competency_description,
-            )
-            self._occupations = dict()
-            self._competency_occupation_edges = set()
+    def __init__(
+        self,
+        edges=None,
+        name=None,
+        competency_name=None,
+        competency_description=None,
+        research_hub_name=None,
+        url=None,
+        jsonld_string=None
+    ):
+        self.name = name
+        self._initialize_empty(competency_name, competency_description)
+        if jsonld_string:
+            self._build_from_jsonld(jsonld_string)
+        elif url:
+            self._build_from_url(url)
+        elif research_hub_name:
+            self._build_from_research_hub(research_hub_name)
+        elif edges:
+            self._build_from_edges(edges)
 
-    @classmethod
-    def from_jsonld(cls, jsonld_string: Text):
+    def _initialize_empty(self, competency_framework_name, competency_framework_description):
+        self.competency_framework = CompetencyFramework(
+            name=competency_framework_name,
+            description=competency_framework_description,
+        )
+        self._occupations = dict()
+        self._competency_occupation_edges = set()
+
+    def _build_from_research_hub(self, name):
+        self._build_from_url(research_hub_url(name))
+
+    def _build_from_url(self, url):
+        jsonld_string = requests.get(url).content
+        self._build_from_jsonld(jsonld_string)
+
+    def _build_from_jsonld(self, jsonld_string: Text):
         jsonld_input = json.loads(jsonld_string)
-        obj = cls(name=jsonld_input.get('name', 'unnamed ontology'))
+        self.name = jsonld_input.get('name', 'unnamed ontology')
         for competency_jsonld in jsonld_input['competencies']:
-            obj.add_competency(Competency.from_jsonld(competency_jsonld))
+            self.add_competency(Competency.from_jsonld(competency_jsonld))
         for occupation_jsonld in jsonld_input['occupations']:
-            obj.add_occupation(Occupation.from_jsonld(occupation_jsonld))
+            self.add_occupation(Occupation.from_jsonld(occupation_jsonld))
         for edge_jsonld in jsonld_input['edges']:
-            obj.add_edge(edge=CompetencyOccupationEdge.from_jsonld(edge_jsonld))
-
-        return obj
+            self.add_edge(edge=CompetencyOccupationEdge.from_jsonld(edge_jsonld))
         
+    def _build_from_edges(self, edges):
+        self._competency_occupation_edges = edges
+        self.competency_framework.competencies = [edge.competency for edge in edges]
+        self._occupations = dict((edge.occupation.identifier, edge.occupation) for edge in edges)
+
     def __eq__(self, other):
         if isinstance(self, other.__class__):
             return \
@@ -385,6 +423,9 @@ class CompetencyOntology(object):
                 sorted(self.edges, key=lambda edge: edge.identifier)
             ]
         }, sort_keys=True)
+
+    def save(self, storage):
+        storage.write(self.jsonld.encode('utf-8'), self.name + '.json')
 
     @property
     def occupation_counts_per_competency(self):

--- a/skills_ml/ontologies/esco.py
+++ b/skills_ml/ontologies/esco.py
@@ -8,12 +8,22 @@ api_tax = 'https://ec.europa.eu/esco/api/resource/taxonomy?uri=http://data.europ
 
 
 class Esco(CompetencyOntology):
-    def __init__(self):
-        super().__init__()
-        self.is_built = False
-        self.competency_framework.name = 'esco_skills'
-        self.competency_framework.description = 'ESCO Knowledge, Skills/Competencies'
-        self._build()
+    name = 'esco'
+
+    def __init__(self, manual_build=False):
+        if manual_build:
+            logging.info('Manual build specified. Building ESCO CompetencyOntology via direct querying from ESCO. Beware, this could take hours!')
+            super().__init__()
+            self.is_built = False
+            self.competency_framework.name = 'esco_skills'
+            self.competency_framework.description = 'ESCO Knowledge, Skills/Competencies'
+            self._build()
+            self.is_built = True
+        else:
+            # by default, build from research hub
+            logging.info('Building ESCO CompetencyOntology via Research Hub-hosted JSON-LD')
+            super().__init__(research_hub_name='esco')
+
     
     def _build(self):
         if not self.is_built:
@@ -87,7 +97,6 @@ class Esco(CompetencyOntology):
             for skill in allSkills:
                 competency = self.getOrCreateCompetency(skill)
                 self.add_edge(competency=competency, occupation=occupation)
-            self.is_built = True
 
     def _parentProcessing (self, concepts, occupation):
         for iscoGrp in concepts:

--- a/skills_ml/ontologies/onet.py
+++ b/skills_ml/ontologies/onet.py
@@ -32,14 +32,19 @@ majorgroupname = {
 
 
 class Onet(CompetencyOntology):
-    def __init__(self, onet_cache=None):
-        super().__init__()
-        self.is_built = False
-        self.onet_cache = onet_cache or OnetSiteCache()
-        self.name = 'onet'
-        self.competency_framework.name = 'onet_ksat'
-        self.competency_framework.description = 'ONET Knowledge, Skills, Abilities, Tools, and Technology'
-        self._build()
+    def __init__(self, onet_cache=None, manual_build=True):
+        if manual_build:
+            logging.info('Manual build specified. Building O*NET CompetencyOntology via direct querying from O*NET site, or local cache.')
+            super().__init__()
+            self.is_built = False
+            self.onet_cache = onet_cache or OnetSiteCache()
+            self.name = 'onet'
+            self.competency_framework.name = 'onet_ksat'
+            self.competency_framework.description = 'ONET Knowledge, Skills, Abilities, Tools, and Technology'
+            self._build()
+        else:
+            logging.info('Building O*NET CompetencyOntology via Research Hub-hosted JSON-LD')
+            super().__init__(research_hub_name='onet')
 
     def _build(self):
         if not self.is_built:


### PR DESCRIPTION
- Add URL, Research Hub options for instantiating ontology. Rearrange
existing options so the constructor isn't too complex
- Add save option to Ontology to make it easier to save/publish
ontologies once they are built
- Finish up ESCO documentation on site