### PR TITLE
Eval cls

### DIFF
--- a/examples/TrainOccupationClassifier.py
+++ b/examples/TrainOccupationClassifier.py
@@ -1,4 +1,4 @@
-from skills_ml.storage import FSStore
+from skills_ml.storage import ModelStorage, FSStore
 
 from skills_ml.job_postings.common_schema import  JobPostingCollectionSample
 from skills_ml.job_postings.filtering import JobPostingFilterer
@@ -33,7 +33,8 @@ test_bytes = json.dumps(test_data).encode()
 
 
 logging.info("Loading Embedding Model")
-w2v = Word2VecModel.load(storage=FSStore('tmp'), model_name='your-embedding-model')
+model_storage = ModelStorage(FSStore('/your/model/path'))
+w2v = model_storage.load_model(model_name='your_model_name')
 
 full_soc = FullSOC()
 
@@ -42,7 +43,7 @@ def basic_filter(doc):
     Return the document except for the document which soc is unknown or empty or not in the
     soc code pool of current O*Net version
     """
-    if full_soc.filter_func(doc) and doc['onet_soc_code'] in full_soc.onet.all_soc:
+    if full_soc.filter_func(doc) and doc['onet_soc_code'] in full_soc.choices:
         return doc
     else:
         return None
@@ -86,7 +87,7 @@ grid_config = {
                      'max_depth': [20, 50],
                      'max_features': ['log2'],
                      'min_samples_split': [10, 20]
-                     },
+                      },
                  'sklearn.ensemble.RandomForestClassifier': {
                      'n_estimators': [50, 100, 500, 1000],
                      'criterion': ['entropy'],

--- a/skills_ml/algorithms/occupation_classifiers/__init__.py
+++ b/skills_ml/algorithms/occupation_classifiers/__init__.py
@@ -18,20 +18,8 @@ class SocEncoder(LabelEncoder):
         self.fit(label_list)
 
 unknown_soc_filter = lambda job: job['onet_soc_code'][:2] != '99'
-
-# def unknow_soc_filter(job_posting):
-#     if job_posting['onet_soc_code'][:2] != '99':
-#         return True
-#     else:
-#         return False
-
 empty_soc_filter = lambda job: job['onet_soc_code'] != ''
 
-# def empty_soc_filter(job_posting):
-#     if job_posting['onet_soc_code'] != '':
-#         return True
-#     else:
-#         return False
 
 class TargetVariable(ABC):
     def __init__(self, filters=None):
@@ -91,7 +79,6 @@ class FullSOC(TargetVariable):
     def __init__(self, filters=None, onet_cache=None):
         super().__init__(filters)
         self.default_filters = [unknown_soc_filter, empty_soc_filter]
-        # self.onet = Onet(onet_cache)
         self.choices = all_soc
         self.encoder = SocEncoder(self.choices)
 

--- a/skills_ml/algorithms/occupation_classifiers/__init__.py
+++ b/skills_ml/algorithms/occupation_classifiers/__init__.py
@@ -54,14 +54,6 @@ class TargetVariable(ABC):
     def extract_occupation_from_jobposting(self, job_posting):
         pass
 
-    def __getstate__(self):
-        result = self.__dict__.copy()
-        result['ontology'] = None
-        return result
-
-    def __setstate__(self, state):
-        self.__dict__ = state
-
 
 class SOCMajorGroup(TargetVariable):
     name = 'major_group'
@@ -86,8 +78,7 @@ class FullSOC(TargetVariable):
     def __init__(self, filters=None, onet_cache=None):
         super().__init__(filters)
         self.default_filters = [unknown_soc_filter, empty_soc_filter]
-        self.ontology = Onet()
-        self.choices = self.ontology.all_soc
+        self.choices = Onet().all_soc
         self.encoder = SocEncoder(self.choices)
 
     def extract_occupation_from_jobposting(self, job_posting):

--- a/skills_ml/algorithms/occupation_classifiers/__init__.py
+++ b/skills_ml/algorithms/occupation_classifiers/__init__.py
@@ -10,14 +10,28 @@ from itertools import zip_longest, tee
 from typing import Generator
 import logging
 
+onet = Onet()
+
+all_soc = onet.all_soc
 class SocEncoder(LabelEncoder):
     def __init__(self, label_list):
         self.fit(label_list)
 
-
 unknown_soc_filter = lambda job: job['onet_soc_code'][:2] != '99'
+
+# def unknow_soc_filter(job_posting):
+#     if job_posting['onet_soc_code'][:2] != '99':
+#         return True
+#     else:
+#         return False
+
 empty_soc_filter = lambda job: job['onet_soc_code'] != ''
 
+# def empty_soc_filter(job_posting):
+#     if job_posting['onet_soc_code'] != '':
+#         return True
+#     else:
+#         return False
 
 class TargetVariable(ABC):
     def __init__(self, filters=None):
@@ -77,8 +91,8 @@ class FullSOC(TargetVariable):
     def __init__(self, filters=None, onet_cache=None):
         super().__init__(filters)
         self.default_filters = [unknown_soc_filter, empty_soc_filter]
-        self.onet = Onet(onet_cache)
-        self.choices = self.onet.all_soc
+        # self.onet = Onet(onet_cache)
+        self.choices = all_soc
         self.encoder = SocEncoder(self.choices)
 
     def extract_occupation_from_jobposting(self, job_posting):

--- a/skills_ml/algorithms/occupation_classifiers/__init__.py
+++ b/skills_ml/algorithms/occupation_classifiers/__init__.py
@@ -10,9 +10,7 @@ from itertools import zip_longest, tee
 from typing import Generator
 import logging
 
-onet = Onet()
 
-all_soc = onet.all_soc
 class SocEncoder(LabelEncoder):
     def __init__(self, label_list):
         self.fit(label_list)
@@ -26,6 +24,7 @@ class TargetVariable(ABC):
         self.default_filters = []
         self.filters = filters
         self.filter_func =  lambda x: all(f(x) for f in self._all_filters)
+        self.ontology = None
 
     @property
     def _all_filters(self):
@@ -55,6 +54,14 @@ class TargetVariable(ABC):
     def extract_occupation_from_jobposting(self, job_posting):
         pass
 
+    def __getstate__(self):
+        result = self.__dict__.copy()
+        result['ontology'] = None
+        return result
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+
 
 class SOCMajorGroup(TargetVariable):
     name = 'major_group'
@@ -79,7 +86,8 @@ class FullSOC(TargetVariable):
     def __init__(self, filters=None, onet_cache=None):
         super().__init__(filters)
         self.default_filters = [unknown_soc_filter, empty_soc_filter]
-        self.choices = all_soc
+        self.ontology = Onet()
+        self.choices = self.ontology.all_soc
         self.encoder = SocEncoder(self.choices)
 
     def extract_occupation_from_jobposting(self, job_posting):

--- a/skills_ml/algorithms/occupation_classifiers/classifiers.py
+++ b/skills_ml/algorithms/occupation_classifiers/classifiers.py
@@ -42,10 +42,10 @@ class SocClassifier(object):
 
 
 class CombinedClassifier(object):
-    def __init__(self, embedding, classifier, target_variable,  **kwargs):
+    def __init__(self, embedding, classifier, **kwargs):
         self.embedding = SerializedByStorage(embedding)
         self.classifier = SerializedByStorage(classifier)
-        self.target_variable = target_variable
+        self.target_variable = self.classifier.target_variable
 
     @property
     def combined(self):
@@ -53,6 +53,9 @@ class CombinedClassifier(object):
             ('tokens_to_vector', EmbeddingTransformer(self.embedding)),
             ('classify', self.classifier)
         ])
+
+    def predict(self, tokenized_words):
+        return self.combined.predict(tokenized_words)
 
     def predict_soc(self, tokenized_words):
         result = self.target_variable.encoder.inverse_transform(self.combined.predict(tokenized_words)), self.combined.predict_proba(tokenized_words)

--- a/skills_ml/algorithms/occupation_classifiers/test.py
+++ b/skills_ml/algorithms/occupation_classifiers/test.py
@@ -14,19 +14,23 @@ class OccupationClassifierTester(object):
             classifier: CombinedClassifier):
         self.test_data_generator = test_data_generator
         self.classifier = classifier
-        self.target_variable = self.classifier.target_variable
         self._preprocessing_X= preprocessing
         self._preprocessing_y = [self.target_variable.transformer]
         self.counter = 0
-        self.pipeline_X = None
-        self.pipeline_y = None
-        self._build_pipeline()
 
-    def _build_pipeline(self):
+    @property
+    def target_variable(self):
+        return self.classifier.target_variable
+
+    @property
+    def pipeline_X(self):
         steps = self._preprocessing_X.copy()
         steps.append(lambda x: self.classifier.predict([x]))
-        self.pipeline_X = IterablePipeline(*steps)
-        self.pipeline_y = IterablePipeline(*self._preprocessing_y)
+        return IterablePipeline(*steps)
+
+    @property
+    def pipeline_y(self):
+        return IterablePipeline(*self._preprocessing_y)
 
     def create_test_generator(self):
         for d in self.test_data_generator:

--- a/skills_ml/algorithms/occupation_classifiers/test.py
+++ b/skills_ml/algorithms/occupation_classifiers/test.py
@@ -1,0 +1,46 @@
+from skills_ml.algorithms.preprocessing import IterablePipeline
+from skills_ml.algorithms.occupation_classifiers.classifiers import CombinedClassifier
+from skills_ml.algorithms.string_cleaners import nlp
+from skills_ml.job_postings.common_schema import JobPostingGeneratorType
+
+from typing import List, Callable
+from functools import partial
+from itertools import tee
+
+class OccupationClassifierTester(object):
+    def __init__(self,
+            test_data_generator: JobPostingGeneratorType,
+            preprocessing: List[Callable],
+            classifier: CombinedClassifier):
+        self.test_data_generator = test_data_generator
+        self.classifier = classifier
+        self.target_variable = self.classifier.target_variable
+        self._preprocessing_X= preprocessing
+        self._preprocessing_y = [self.target_variable.transformer]
+        self.counter = 0
+        self.pipeline_X = None
+        self.pipeline_y = None
+        self._build_pipeline()
+
+    def _build_pipeline(self):
+        steps = self._preprocessing_X.copy()
+        steps.append(lambda x: self.classifier.predict([x]))
+        self.pipeline_X = IterablePipeline(*steps)
+        self.pipeline_y = IterablePipeline(*self._preprocessing_y)
+
+    def create_test_generator(self):
+        for d in self.test_data_generator:
+            if self.target_variable.filter(d):
+                yield d
+            else:
+                raise AttributeError("Not valid onet soc code")
+
+    def __iter__(self):
+        test_X, test_y = tee(self.create_test_generator())
+        for predict, label in zip(self.pipeline_X.build(test_X), self.pipeline_y.build(test_y)):
+            yield [predict[0], label[0]]
+            self.counter += 1
+
+    def __len__(self):
+        return self.counter
+

--- a/skills_ml/algorithms/occupation_classifiers/test.py
+++ b/skills_ml/algorithms/occupation_classifiers/test.py
@@ -43,4 +43,3 @@ class OccupationClassifierTester(object):
 
     def __len__(self):
         return self.counter
-

--- a/skills_ml/algorithms/occupation_classifiers/train.py
+++ b/skills_ml/algorithms/occupation_classifiers/train.py
@@ -16,7 +16,7 @@ import logging
 from datetime import datetime
 from itertools import zip_longest, tee
 from typing import Type, Union
-import pickle
+import dill
 import os
 
 
@@ -124,4 +124,5 @@ class OccupationClassifierTrainer(object):
 
     def _save(self, cls_cv, path_to_save):
         with open_sesame(path_to_save, 'wb') as f:
-            joblib.dump(cls_cv, f, compress=True)
+            dill.dump(cls_cv, f)
+

--- a/skills_ml/algorithms/occupation_classifiers/train.py
+++ b/skills_ml/algorithms/occupation_classifiers/train.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from itertools import zip_longest, tee
 from typing import Type, Union
 import dill
-
+import inspect
 import os
 
 
@@ -83,16 +83,16 @@ class OccupationClassifierTrainer(object):
                 model_hash = self._model_hash(self.matrix.metadata, class_name, parameter_config)
                 trained_model_name = class_name.lower() + "_" + model_hash
                 self.storage.path = os.path.join(store_path, score, trained_model_name)
-                if class_name == "SVC" or class_name == "MLPClassifier":
+                if 'n_jobs' in inspect.signature(cls).parameters.keys():
                     cls_cv = ProxyObjectWithStorage(
-                            model_obj=GridSearchCV(estimator=cls(), param_grid=parameter_config, cv=kf, scoring=score),
+                            model_obj=GridSearchCV(estimator=cls(n_jobs=self.n_jobs), param_grid=parameter_config, cv=kf, scoring=score),
                             storage=self.storage,
                             model_name=trained_model_name,
                             target_variable=self.matrix.target_variable
                             )
                 else:
                     cls_cv = ProxyObjectWithStorage(
-                            model_obj=GridSearchCV(estimator=cls(n_jobs=self.n_jobs), param_grid=parameter_config, cv=kf, scoring=score),
+                            model_obj=GridSearchCV(estimator=cls(), param_grid=parameter_config, cv=kf, scoring=score),
                             storage=self.storage,
                             model_name=trained_model_name,
                             target_variable=self.matrix.target_variable

--- a/skills_ml/algorithms/occupation_classifiers/train.py
+++ b/skills_ml/algorithms/occupation_classifiers/train.py
@@ -85,14 +85,21 @@ class OccupationClassifierTrainer(object):
                 self.storage.path = os.path.join(store_path, score, trained_model_name)
                 if 'n_jobs' in inspect.signature(cls).parameters.keys():
                     cls_cv = ProxyObjectWithStorage(
-                            model_obj=GridSearchCV(estimator=cls(n_jobs=self.n_jobs), param_grid=parameter_config, cv=kf, scoring=score),
+                            model_obj=GridSearchCV(
+                                estimator=cls(n_jobs=self.n_jobs),
+                                param_grid=parameter_config,
+                                cv=kf, scoring=score),
                             storage=self.storage,
                             model_name=trained_model_name,
                             target_variable=self.matrix.target_variable
                             )
                 else:
                     cls_cv = ProxyObjectWithStorage(
-                            model_obj=GridSearchCV(estimator=cls(), param_grid=parameter_config, cv=kf, scoring=score),
+                            model_obj=GridSearchCV(
+                                estimator=cls(),
+                                param_grid=parameter_config,
+                                cv=kf,
+                                scoring=score),
                             storage=self.storage,
                             model_name=trained_model_name,
                             target_variable=self.matrix.target_variable

--- a/skills_ml/algorithms/occupation_classifiers/train.py
+++ b/skills_ml/algorithms/occupation_classifiers/train.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from itertools import zip_longest, tee
 from typing import Type, Union
 import dill
+
 import os
 
 

--- a/skills_ml/algorithms/skill_extractors/section_extract.py
+++ b/skills_ml/algorithms/skill_extractors/section_extract.py
@@ -36,6 +36,7 @@ class SectionExtractSkillExtractor(SkillExtractor):
                 matched_skill_identifier=None,
                 confidence=100,
                 context=line,
+                start_index=-1,
                 document_id=source_object['id'],
                 document_type=source_object['@type'],
                 source_object=source_object,

--- a/skills_ml/evaluation/occ_cls_evaluator.py
+++ b/skills_ml/evaluation/occ_cls_evaluator.py
@@ -1,0 +1,117 @@
+from sklearn import metrics
+from descriptors import cachedproperty
+
+import logging
+import numpy as np
+
+class ClassificationEvaluator(object):
+    def __init__(self, result_generator):
+        self.result_generator = result_generator
+        if not hasattr(self.result_generator,'target_variable'):
+            raise AttributeError("the result_generator should have target_variable property")
+        else:
+            self.target_variable = self.result_generator.target_variable
+            self.labels = self.target_variable.choices
+        self.result = np.array(list(result_generator))
+
+    @cachedproperty
+    def y_pred(self):
+        return self.target_variable.encoder.inverse_transform(self.result[:, 0])
+
+    @cachedproperty
+    def y_true(self):
+        return self.target_variable.encoder.inverse_transform(self.result[:, 1])
+
+    @cachedproperty
+    def accuracy(self):
+        return metrics.accuracy_score(self.y_true, self.y_pred)
+
+    @cachedproperty
+    def precision(self):
+        return metrics.precision_score(self.y_true, self.y_pred, labels=self.labels, average=None)
+
+    @cachedproperty
+    def recall(self):
+        return metrics.recall_score(self.y_true, self.y_pred, labels=self.labels, average=None)
+
+    @cachedproperty
+    def f1(self):
+        return metrics.f1_score(self.y_true, self.y_pred, labels=self.labels, average=None)
+
+    @cachedproperty
+    def confusion_matrix(self):
+        return metrics.confusion_matrix(self.y_true, self.y_pred)
+
+    @cachedproperty
+    def macro_precision(self):
+        return metrics.precision_score(self.y_true, self.y_pred, average='macro')
+
+    @cachedproperty
+    def micro_precision(self):
+        return metrics.precision_score(self.y_true, self.y_pred, average='micro')
+
+    @cachedproperty
+    def macro_recall(self):
+        return metrics.recall_score(self.y_true, self.y_pred, average='macro')
+
+    @cachedproperty
+    def micro_recall(self):
+        return metrics.recall_score(self.y_true, self.y_pred, average='micro')
+
+    @cachedproperty
+    def macro_f1(self):
+        return metrics.f1_score(self.y_true, self.y_pred, average='macro')
+
+    @cachedproperty
+    def micro_f1(self):
+        return metrics.f1_score(self.y_true, self.y_pred, average='micro')
+
+
+class OnetOccupationClassificationEvaluator(ClassificationEvaluator):
+    def __init__(self,result_generator):
+        super().__init__(result_generator)
+        if not hasattr(self.result_generator,'target_variable'):
+            raise AttributeError("the result_generator should have target_variable property")
+        else:
+            self.target_variable = self.result_generator.target_variable
+            self.labels = self.target_variable.choices
+        self.result = np.array(list(result_generator))
+
+    @cachedproperty
+    def _result_for_major_group(self):
+        y_pred = [p[:2] for p in self.y_pred]
+        y_true = [t[:2] for t in self.y_true]
+        return y_true, y_pred
+
+    @cachedproperty
+    def accuracy_major_group(self):
+        if self.target_variable.name == 'full_soc':
+            y_true, y_pred = self._result_for_major_group
+            return metrics.accuracy_score(y_true, y_pred)
+
+        elif self.target_variable.name == 'major_group':
+            return self.accuracy
+
+    @cachedproperty
+    def recall_per_major_group(self):
+        if self.target_variable.name == 'major_group':
+            return self.recall
+        elif self.target_variable.name == 'full_soc':
+            y_true, y_pred = self._result_for_major_group
+            return metrics.recall_score(y_true, y_pred, average=None)
+
+    @cachedproperty
+    def precision_per_major_group(self):
+        if self.target_variable.name == 'major_group':
+            return self.precision
+        elif self.target_variable.name == 'full_soc':
+            y_true, y_pred = self._result_for_major_group
+            return metrics.precision_score(y_true, y_pred, average=None)
+
+    @cachedproperty
+    def f1_per_major_group(self):
+        if self.target_variable.name == 'major_group':
+            return self.f1
+        elif self.target_variable.name ==  'full_soc':
+            y_true, y_pred = self._result_for_major_group
+            return metrics.f1_score(y_true, y_pred, average=None)

--- a/skills_ml/storage/__init__.py
+++ b/skills_ml/storage/__init__.py
@@ -31,21 +31,22 @@ class ProxyObjectWithStorage(wrapt.ObjectProxy):
         storage (skills_ml.storage.Store): the skill_ml storage object
         model_obj (object): target model object
         model_name (str): model name
-
+        target_variable ():
     """
-    __slots__ = ('storage', 'model_name','by_ref')
-    def __init__(self, model_obj, storage=None, model_name=None):
+    __slots__ = ('storage', 'model_name','target_variable')
+    def __init__(self, model_obj, storage=None, model_name=None, target_variable=None):
         self.storage = storage
         self.model_name = model_name
+        self.target_variable = target_variable
         super().__init__(model_obj)
         self._model_obj = model_obj
 
     @classmethod
-    def __reconstruct__(cls, model_obj, storage, model_name):
-        return cls(model_obj, storage, model_name)
+    def __reconstruct__(cls, model_obj, storage, model_name, target_variable):
+        return cls(model_obj, storage, model_name, target_variable)
 
     def __reduce__(self):
-        return (self.__reconstruct__, (self._model_obj, self.storage, self.model_name))
+        return (self.__reconstruct__, (self._model_obj, self.storage, self.model_name, self.target_variable))
 
 
 @retry(stop_max_delay=150000, wait_fixed=3000)

--- a/tests/algorithms/test_occupation_classifier_tester.py
+++ b/tests/algorithms/test_occupation_classifier_tester.py
@@ -69,7 +69,6 @@ class TestOccupationClassifierTester(unittest.TestCase):
         train_matrix.build()
         occ_trainer = OccupationClassifierTrainer(train_matrix, 2, grid_config=self.grid_config)
         occ_trainer.train(save=False)
-        print(occ_trainer.best_estimators[0].target_variable)
         cc = CombinedClassifier(w2v, occ_trainer.best_estimators[0])
 
         steps = self.pipe_x.generators[:-1]

--- a/tests/algorithms/test_occupation_classifier_tester.py
+++ b/tests/algorithms/test_occupation_classifier_tester.py
@@ -1,0 +1,82 @@
+from skills_ml.algorithms.occupation_classifiers.classifiers import CombinedClassifier
+from skills_ml.algorithms.occupation_classifiers.train import OccupationClassifierTrainer
+from skills_ml.algorithms.occupation_classifiers.test import OccupationClassifierTester
+from skills_ml.algorithms.occupation_classifiers import DesignMatrix, FullSOC
+from skills_ml.algorithms.embedding.models import Word2VecModel
+from skills_ml.algorithms.embedding.train import EmbeddingTrainer
+from skills_ml.algorithms.string_cleaners import nlp
+from skills_ml.algorithms.preprocessing import IterablePipeline
+
+from skills_ml.job_postings.common_schema import JobPostingCollectionSample
+from skills_ml.job_postings.corpora import Word2VecGensimCorpusCreator
+
+from sklearn.ensemble import RandomForestClassifier
+
+from descriptors import cachedproperty
+
+from functools import partial
+from itertools import islice
+import unittest
+
+class TestOccupationClassifierTester(unittest.TestCase):
+    @cachedproperty
+    def fullsoc(self):
+        return FullSOC()
+
+    @property
+    def pipe_x(self):
+        document_schema_fields = ['description', 'experienceRequirements', 'qualifications', 'skills']
+        pipe_x = IterablePipeline(
+                self.fullsoc.filter,
+                partial(nlp.fields_join, document_schema_fields=document_schema_fields),
+                nlp.clean_str,
+                nlp.word_tokenize,
+                partial(nlp.vectorize, embedding_model=Word2VecModel(size=10))
+        )
+        return pipe_x
+
+    @property
+    def pipe_y(self):
+        pipe_y = IterablePipeline(
+                self.fullsoc.filter,
+                self.fullsoc.transformer
+        )
+        return pipe_y
+
+    @property
+    def grid_config(self):
+        return {
+                'sklearn.ensemble.RandomForestClassifier': {
+                    'n_estimators': [5, 10],
+                    'criterion': ['entropy'],
+                    'max_depth': [1],
+                    'max_features': ['log2'],
+                    'min_samples_split': [5]
+                    }
+                }
+
+    def test_tester(self):
+        document_schema_fields = ['description','experienceRequirements', 'qualifications', 'skills']
+        corpus_generator = Word2VecGensimCorpusCreator(JobPostingCollectionSample(num_records=30), document_schema_fields=document_schema_fields)
+        w2v = Word2VecModel(size=10, min_count=3, iter=4, window=6, workers=3)
+        trainer = EmbeddingTrainer(corpus_generator, w2v)
+        trainer.train()
+
+        jp = JobPostingCollectionSample()
+        train_gen = islice(jp, 30)
+        test_gen = islice(jp, 30, None)
+        train_matrix = DesignMatrix(train_gen, self.fullsoc, self.pipe_x, self.pipe_y)
+        train_matrix.build()
+        occ_trainer = OccupationClassifierTrainer(train_matrix, 2, grid_config=self.grid_config)
+        occ_trainer.train(save=False)
+        print(occ_trainer.best_estimators[0].target_variable)
+        cc = CombinedClassifier(w2v, occ_trainer.best_estimators[0])
+
+        steps = self.pipe_x.generators[:-1]
+
+        test_gen = (t for t in test_gen if t['onet_soc_code'] is not '')
+
+        tester = OccupationClassifierTester(test_data_generator=test_gen, preprocessing=steps, classifier=cc)
+        result = list(tester)
+
+        assert len(tester) == len(result) == 18

--- a/tests/algorithms/test_train_occupation_classifiers.py
+++ b/tests/algorithms/test_train_occupation_classifiers.py
@@ -93,7 +93,7 @@ class TestClassifierTrainer(unittest.TestCase):
         return list(JobPostingFilterer(self.jobpostings, filters))
 
     def test_full_soc(self):
-        job_posting = {'onet_soc_code': '11-1031.00'}
+        job_posting = {'onet_soc_code': '11-1031.00', 'id': 'some_id_number'}
         assert self.full_soc.transformer(job_posting)[0] == [3]
 
     def test_design_matrix(self):

--- a/tests/evaluation/test_occ_cls.py
+++ b/tests/evaluation/test_occ_cls.py
@@ -1,0 +1,43 @@
+import unittest
+import numpy as np
+from skills_ml.evaluation.occ_cls_evaluator import ClassificationEvaluator, OnetOccupationClassificationEvaluator
+from skills_ml.algorithms.occupation_classifiers import FullSOC
+
+class FakeResultGenerator(object):
+    def __init__(self):
+        self.y_true = [0, 1, 200, 0, 1, 200, 0, 1, 200, 0, 1, 200]
+        self.y_pred = [0, 1, 200, 1, 200, 0, 1, 1, 1, 0, 1, 0]
+        self.target_variable = FullSOC()
+
+    def __iter__(self):
+        for r in zip(self.y_pred, self.y_true):
+            yield r
+
+class TestOccupationClassifierEvaluator(unittest.TestCase):
+    def test_classification_evaluator(self):
+        evaluator = ClassificationEvaluator(result_generator=FakeResultGenerator())
+
+        p = evaluator.precision[np.nonzero(evaluator.precision)]
+        r = evaluator.recall[np.nonzero(evaluator.recall)]
+
+        assert evaluator.accuracy == 0.5
+        self.assertSequenceEqual(list(p), [0.5, 0.5 , 0.5])
+        self.assertSequenceEqual(list(r), [0.5 , 0.75, 0.25])
+        self.assertSequenceEqual(list(evaluator.f1[np.nonzero(evaluator.f1)]), list(2 * r * p / (r + p)))
+        assert evaluator.micro_precision == 0.5
+        assert evaluator.micro_recall == 0.5
+        assert evaluator.macro_precision == 0.5
+        assert evaluator.macro_recall == 0.5
+        assert evaluator.micro_f1 == 0.5
+        self.assertAlmostEqual(evaluator.macro_f1, 0.477, places=2)
+
+    def test_onet_occupation_classification_evaulator(self):
+        onet_evaluator = OnetOccupationClassificationEvaluator(result_generator=FakeResultGenerator())
+
+        r = onet_evaluator.recall_per_major_group
+        p =  onet_evaluator.precision_per_major_group
+
+        self.assertAlmostEqual(onet_evaluator.accuracy_major_group, 0.6666666, places=2)
+        self.assertSequenceEqual(list(onet_evaluator.recall_per_major_group), [0.875, 0.25 ])
+        self.assertSequenceEqual(list(onet_evaluator.precision_per_major_group), [0.7, 0.5])
+        self.assertSequenceEqual(list(onet_evaluator.f1_per_major_group), list(2 * r * p / (r + p)))


### PR DESCRIPTION
- introduced `OccupationClassifierTester` which takes in `test_data_generator`, `preprocessing` and `classifier`.  `test_data_generator` is a JobPostingGeneratorType generator. `preprocessing` is a list of functions that will perform the preprocessing steps on the job posting data for testing. the classifier is a CombinedClassifier that takes in one embedding model and one classifier. 
`OccupationClassifierTester` itself is a generator as well, which yields a pair of predicted result and label for a job posting. 

- introduced `ClassificationEvaluator` and `OnetOccupationClassificationEvaluator` which takes in a result_generator like `OccupationClassifierTester` or a generator object that produces a pair of predicted result and label and has a `target_variable` attribute. 
    - `ClassificationEvaluator` will calculate accuracy, precision, recall, f1, plus the micro- and macro- version of those metrics. 
    - `OnetOccupationClassificationEvaluator` has all the attributes that `ClassificationEvaluator` has but add metrics for specific onet major group, such as recall_per_major_group, precision_per_major_group and f1_per_major_group.

