### PR TITLE
Fixed IterablePipeline for yielding None

### DIFF
--- a/skills_ml/algorithms/preprocessing/__init__.py
+++ b/skills_ml/algorithms/preprocessing/__init__.py
@@ -108,7 +108,7 @@ def func2gen(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(*args, **kwargs):
             for item in args[0]:
-                if item is not None:
+                if func(item) is not None:
                     yield func(item)
         return wrapper
 


### PR DESCRIPTION
The `if` statement here is to prevent the generator from yielding `None`. The way it was implemented will still yield `None` if the `func(item)` is None. 